### PR TITLE
docs: Update examples on scripts execution

### DIFF
--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -434,17 +434,17 @@ receive incoming tasks, execute them, and send back the results to the master.
 
 When using MPICH implementation or its derivatives based on the Hydra process
 manager, the MPI universe size can be set via ``-usize`` argument to
-:program:`mpiexec` ::
+:program:`mpiexec`::
 
   $ mpiexec -n 1 -usize 17 python julia.py
 
 or, alternatively, by setting the :envvar:`MPIEXEC_UNIVERSE_SIZE` environment
-variable ::
+variable::
 
   $ MPIEXEC_UNIVERSE_SIZE=17 mpiexec -n 1 python julia.py
 
 In the Open MPI implementation, the MPI universe size can be set via ``-host``
-argument to :program:`mpiexec` ::
+argument to :program:`mpiexec`::
 
   $ mpiexec -n 1 -host <hostname>:17 python julia.py
 
@@ -458,7 +458,7 @@ Notice that in this case MPI universe size is ignored.
 Alternatively, users may decide to execute the script in a more traditional
 way, that is, all the MPI process are started at once. The user script is run
 under command line control of :mod:`mpi4py.futures` passing the :ref:`-m
-<python:using-on-cmdline>` flag to the :program:`python` executable. ::
+<python:using-on-cmdline>` flag to the :program:`python` executable::
 
   $ mpiexec -n 17 python -m mpi4py.futures julia.py
 

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -435,7 +435,7 @@ and waits for the results. The workers receive incoming tasks, execute them,
 and send back the results to the master.
 
 When using MPICH implementation or its derivatives based on the Hydra process
-manager, the MPI universe size can be set via ``-usize`` argument to
+manager, the user can set the MPI universe size via ``-usize`` argument to
 :program:`mpiexec`::
 
   $ mpiexec -n 1 -usize 17 python julia.py
@@ -455,18 +455,18 @@ Another way to specify the number of workers is to use a
 
   $ MPI4PY_MAX_WORKERS=16 mpiexec -n 1 python julia.py
   
-Note that in this case the MPI universe size is ignored.
+Note that in this case, the MPI universe size is ignored.
 
 Alternatively, users may decide to execute the script in a more traditional
-way, that is, all the MPI process are started at once. The user script is run
-under command line control of :mod:`mpi4py.futures` passing the :ref:`-m
+way, that is, all the MPI processes are started at once. The user script is run
+under command-line control of :mod:`mpi4py.futures` passing the :ref:`-m
 <python:using-on-cmdline>` flag to the :program:`python` executable::
 
   $ mpiexec -n 17 python -m mpi4py.futures julia.py
 
 As explained previously, the 17 processes are partitioned in one master and 16
 workers. The master process executes the main script while the workers execute
-the tasks submitted from the master.
+the tasks submitted by the master.
 
 .. [#] When using an MPI implementation other than MPICH or Open MPI, please
    check the documentation of the implementation and/or batch

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -421,18 +421,39 @@ scanline is dumped to disk.
                for line in image:
                    f.write(line)
 
-The recommended way to execute the script is using the :program:`mpiexec`
+The recommended way to execute the script is by using the :program:`mpiexec`
 command specifying one MPI process and (optional but recommended) the desired
-MPI universe size [#]_. ::
+`MPI universe size <https://www.mcs.anl.gov/research/projects/mpi/mpi-standard/mpi-report-2.0/node111.htm>`_,
+which is provided either by a batch system or is set by the user via
+command-line arguments or environment variables. Below we provide
+examples for MPICH and Open MPI as well as `mpi4py`-specific way [#]_.
+In all of these examples, the :program:`mpiexec` command launches a single MPI
+process (the master) running the Python interpreter and executing the main
+script. When required, :mod:`mpi4py.futures` spawns 16 additional MPI processes
+(the children) to dynamically allocate the pool of workers. The master submits
+tasks to the children and waits for the results. The children receive incoming
+tasks, execute them, and send back the results to the master.
+
+When using MPICH implementation or its derivatives based on the Hydra process
+manager, the MPI universe size can be set via ``-usize`` argument to
+:program:`mpiexec` ::
 
   $ mpiexec -n 1 -usize 17 python julia.py
 
-The :program:`mpiexec` command launches a single MPI process (the master)
-running the Python interpreter and executing the main script. When required,
-:mod:`mpi4py.futures` spawns 16 additional MPI processes (the children) to
-dynamically allocate the pool of workers. The master submits tasks to the
-children and waits for the results. The children receive incoming tasks,
-execute them, and send back the results to the master.
+or, alternatively, by setting the :envvar:`MPIEXEC_UNIVERSE_SIZE` environment
+variable ::
+
+  $ MPIEXEC_UNIVERSE_SIZE=17 mpiexec -n 1 python julia.py
+
+In the Open MPI implementation, the MPI universe size can be set via ``-host``
+argument to :program:`mpiexec` ::
+
+  $ mpiexec -n 1 -host <hostname>:17 python julia.py
+
+Another, implementation-independent, way to specify the MPI universe size is to
+use `mpi4py`-specific environment variable::
+
+  $ MPI4PY_MAX_WORKERS=16 mpiexec -n 1 python julia.py
 
 Alternatively, users may decide to execute the script in a more traditional
 way, that is, all the MPI process are started at once. The user script is run
@@ -445,14 +466,9 @@ As explained previously, the 17 processes are partitioned in one master and 16
 workers. The master process executes the main script while the workers execute
 the tasks submitted from the master.
 
-.. [#] This :program:`mpiexec` invocation example using the ``-usize`` flag
-   (alternatively, setting the :envvar:`MPIEXEC_UNIVERSE_SIZE` environment
-   variable) assumes the backend MPI implementation is an MPICH derivative
-   using the Hydra process manager. In the Open MPI implementation, the MPI
-   universe size can be specified by setting the :envvar:`OMPI_UNIVERSE_SIZE`
-   environment variable to a positive integer.  Check the documentation of your
-   actual MPI implementation and/or batch system for the ways to specify the
-   desired MPI universe size.
+.. [#] When using MPI implementations different from MPICH and Open MPI, please
+   check the documentation of your actual MPI implementation and/or batch
+   system for the ways to specify the desired MPI universe size.
 
 
 .. Local variables:

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -422,15 +422,17 @@ scanline is dumped to disk.
                    f.write(line)
 
 The recommended way to execute the script is by using the :program:`mpiexec`
-command specifying one MPI process and (optional but recommended) the desired
-MPI universe size, which is provided either by a batch system or is set by the
-user via command-line arguments or environment variables. Below we provide
-examples for MPICH and Open MPI [#]_. In all
-of these examples, the :program:`mpiexec` command launches a single MPI process
-(the master) running the Python interpreter and executing the main script. When
-required, :mod:`mpi4py.futures` spawns the pool of 16 worker processes. The
-master submits tasks to the workers and waits for the results. The workers
-receive incoming tasks, execute them, and send back the results to the master.
+command specifying one MPI process (master) and (optional but recommended) the
+desired MPI universe size, which determines the number of additional
+dynamically spawned processes (workers). The MPI universe size is provided
+either by a batch system or set by the user via command-line arguments to
+:program:`mpiexec` or environment variables. Below we provide examples for
+MPICH and Open MPI implementations [#]_. In all of these examples, the
+:program:`mpiexec` command launches a single master process running the Python
+interpreter and executing the main script. When required, :mod:`mpi4py.futures`
+spawns the pool of 16 worker processes. The master submits tasks to the workers
+and waits for the results. The workers receive incoming tasks, execute them,
+and send back the results to the master.
 
 When using MPICH implementation or its derivatives based on the Hydra process
 manager, the MPI universe size can be set via ``-usize`` argument to

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -466,8 +466,8 @@ As explained previously, the 17 processes are partitioned in one master and 16
 workers. The master process executes the main script while the workers execute
 the tasks submitted from the master.
 
-.. [#] When using MPI implementations different from MPICH and Open MPI, please
-   check the documentation of your actual MPI implementation and/or batch
+.. [#] When using an MPI implementation other than MPICH or Open MPI, please
+   check the documentation of the implementation and/or batch
    system for the ways to specify the desired MPI universe size.
 
 

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -423,16 +423,15 @@ scanline is dumped to disk.
 
 The recommended way to execute the script is by using the :program:`mpiexec`
 command specifying one MPI process and (optional but recommended) the desired
-`MPI universe size <https://www.mcs.anl.gov/research/projects/mpi/mpi-standard/mpi-report-2.0/node111.htm>`_,
-which is provided either by a batch system or is set by the user via
-command-line arguments or environment variables. Below we provide
-examples for MPICH and Open MPI as well as `mpi4py`-specific way [#]_.
-In all of these examples, the :program:`mpiexec` command launches a single MPI
-process (the master) running the Python interpreter and executing the main
-script. When required, :mod:`mpi4py.futures` spawns 16 additional MPI processes
-(the children) to dynamically allocate the pool of workers. The master submits
-tasks to the children and waits for the results. The children receive incoming
-tasks, execute them, and send back the results to the master.
+MPI universe size, which is provided either by a batch system or is set by the
+user via command-line arguments or environment variables. Below we provide
+examples for MPICH and Open MPI as well as `mpi4py`-specific way [#]_. In all
+of these examples, the :program:`mpiexec` command launches a single MPI process
+(the master) running the Python interpreter and executing the main script. When
+required, :mod:`mpi4py.futures` spawns 16 additional MPI processes (the
+children) to dynamically allocate the pool of workers. The master submits tasks
+to the children and waits for the results. The children receive incoming tasks,
+execute them, and send back the results to the master.
 
 When using MPICH implementation or its derivatives based on the Hydra process
 manager, the MPI universe size can be set via ``-usize`` argument to

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -428,10 +428,9 @@ user via command-line arguments or environment variables. Below we provide
 examples for MPICH and Open MPI as well as `mpi4py`-specific way [#]_. In all
 of these examples, the :program:`mpiexec` command launches a single MPI process
 (the master) running the Python interpreter and executing the main script. When
-required, :mod:`mpi4py.futures` spawns 16 additional MPI processes (the
-children) to dynamically allocate the pool of workers. The master submits tasks
-to the children and waits for the results. The children receive incoming tasks,
-execute them, and send back the results to the master.
+required, :mod:`mpi4py.futures` spawns the pool of 16 worker processes. The
+master submits tasks to the workers and waits for the results. The workers
+receive incoming tasks, execute them, and send back the results to the master.
 
 When using MPICH implementation or its derivatives based on the Hydra process
 manager, the MPI universe size can be set via ``-usize`` argument to

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -450,7 +450,7 @@ argument to :program:`mpiexec`::
 
   $ mpiexec -n 1 -host <hostname>:17 python julia.py
 
-Another way to specify the number of workers is to use a
+Another way to specify the number of workers is to use the
 `mpi4py.futures`-specific environment variable :envvar:`MPI4PY_MAX_WORKERS`::
 
   $ MPI4PY_MAX_WORKERS=16 mpiexec -n 1 python julia.py

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -425,7 +425,7 @@ The recommended way to execute the script is by using the :program:`mpiexec`
 command specifying one MPI process and (optional but recommended) the desired
 MPI universe size, which is provided either by a batch system or is set by the
 user via command-line arguments or environment variables. Below we provide
-examples for MPICH and Open MPI as well as `mpi4py`-specific way [#]_. In all
+examples for MPICH and Open MPI [#]_. In all
 of these examples, the :program:`mpiexec` command launches a single MPI process
 (the master) running the Python interpreter and executing the main script. When
 required, :mod:`mpi4py.futures` spawns the pool of 16 worker processes. The
@@ -448,10 +448,11 @@ argument to :program:`mpiexec` ::
 
   $ mpiexec -n 1 -host <hostname>:17 python julia.py
 
-Another, implementation-independent, way to specify the number of workers is to
+Another way to specify the number of workers is to
 use `mpi4py`-specific environment variable::
 
   $ MPI4PY_MAX_WORKERS=16 mpiexec -n 1 python julia.py
+  
 Notice that in this case MPI universe size is ignored.
 
 Alternatively, users may decide to execute the script in a more traditional

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -448,12 +448,12 @@ argument to :program:`mpiexec`::
 
   $ mpiexec -n 1 -host <hostname>:17 python julia.py
 
-Another way to specify the number of workers is to
-use `mpi4py`-specific environment variable::
+Another way to specify the number of workers is to use a
+`mpi4py.futures`-specific environment variable :envvar:`MPI4PY_MAX_WORKERS`::
 
   $ MPI4PY_MAX_WORKERS=16 mpiexec -n 1 python julia.py
   
-Notice that in this case MPI universe size is ignored.
+Note that in this case the MPI universe size is ignored.
 
 Alternatively, users may decide to execute the script in a more traditional
 way, that is, all the MPI process are started at once. The user script is run

--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -449,10 +449,11 @@ argument to :program:`mpiexec` ::
 
   $ mpiexec -n 1 -host <hostname>:17 python julia.py
 
-Another, implementation-independent, way to specify the MPI universe size is to
+Another, implementation-independent, way to specify the number of workers is to
 use `mpi4py`-specific environment variable::
 
   $ MPI4PY_MAX_WORKERS=16 mpiexec -n 1 python julia.py
+Notice that in this case MPI universe size is ignored.
 
 Alternatively, users may decide to execute the script in a more traditional
 way, that is, all the MPI process are started at once. The user script is run


### PR DESCRIPTION
This PR updates documentation on how to run scripts with dynamically spawned processes for Open MPI implementation as well as adds an example with using MPI4PY_MAX_WORKERS env variable.

It is based on the discussion https://github.com/open-mpi/ompi/issues/8171

