### PR TITLE
[DOC] Fix typos.

### DIFF
--- a/docs/source/usrman/mpi4py.futures.rst
+++ b/docs/source/usrman/mpi4py.futures.rst
@@ -69,7 +69,7 @@ only) thread until they are signaled for completion.
    The worker processes must import the main script in order to *unpickle* any
    callable defined in the :mod:`__main__` module and submitted from the master
    process. Furthermore, the callables may need access to other global
-   variables. At the worker processes,:mod:`mpi4py.futures` executes the main
+   variables. At the worker processes, :mod:`mpi4py.futures` executes the main
    script code (using the :mod:`runpy` module) under the :mod:`__worker__`
    namespace to define the :mod:`__main__` module. The :mod:`__main__` and
    :mod:`__worker__` modules are added to :data:`sys.modules` (both at the

--- a/docs/source/usrman/tutorial.rst
+++ b/docs/source/usrman/tutorial.rst
@@ -15,7 +15,7 @@ communication of buffer-provider objects (e.g., NumPy arrays).
 
   You have to use **all-lowercase** methods (of the :class:`Comm`
   class), like :meth:`send()`, :meth:`recv()`, :meth:`bcast()`. An
-  object to be sent is passed as a paramenter to the communication
+  object to be sent is passed as a parameter to the communication
   call, and the received object is simply the return value.
 
   The :meth:`isend()` and :meth:`irecv` methods return


### PR DESCRIPTION
Hi! I was reading the documentation to familiarize myself with mpi4py. This PR fixes a couple small errors - a missing space that caused Sphinx rendering problems, and a typo. Thank you for your work on mpi4py, it is a very helpful tool!