### PR TITLE
test: Alignment of send/receive buffers and data types in test_rma

### DIFF
--- a/test/test_rma.py
+++ b/test/test_rma.py
@@ -161,6 +161,7 @@ class BaseTestRMA(object):
                         self.assertEqual(gbuf[-1], -1)
 
     def testFetchAndOp(self):
+        typemap = MPI._typedict
         group = self.WIN.Get_group()
         size = group.Get_size()
         rank = group.Get_rank()
@@ -187,6 +188,7 @@ class BaseTestRMA(object):
             if typecode in 'FDG': continue
             obuf = array(+1, typecode)
             rbuf = array(-1, typecode, 2)
+            datatype = typemap[typecode]
             for op in (MPI.SUM, MPI.PROD,
                        MPI.MAX, MPI.MIN,
                        MPI.REPLACE, MPI.NO_OP):
@@ -195,11 +197,15 @@ class BaseTestRMA(object):
                         self.WIN.Lock(rank)
                         self.WIN.Fetch_and_op(obuf.as_mpi(),
                                               rbuf.as_mpi_c(1),
-                                              rank, disp, op=op)
+                                              rank,
+                                              disp * datatype.size,
+                                              op=op)
+
                         self.WIN.Unlock(rank)
                         self.assertEqual(rbuf[1], -1)
 
     def testCompareAndSwap(self):
+        typemap = MPI._typedict
         group = self.WIN.Get_group()
         size = group.Get_size()
         rank = group.Get_rank()
@@ -229,13 +235,16 @@ class BaseTestRMA(object):
             obuf = array(+1, typecode)
             cbuf = array( 0, typecode)
             rbuf = array(-1, typecode, 2)
+            datatype = typemap[typecode]
             for rank in range(size):
                 for disp in range(3):
                     self.WIN.Lock(rank)
                     self.WIN.Compare_and_swap(obuf.as_mpi(),
                                               cbuf.as_mpi(),
                                               rbuf.as_mpi_c(1),
-                                              rank, disp)
+                                              rank,
+                                              disp * datatype.size)
+
                     self.WIN.Unlock(rank)
                     self.assertEqual(rbuf[1], -1)
 


### PR DESCRIPTION
In this pull request, I fixed a violation of the MPI standard in the way MPI_Compare_and_swap and MPI_Fetch_and_op are called in test_rma.py.
 
I fixed it like a pull request and it now passes, but I feel like it's weird to fix the disp, so do you know the right way to do it?
 
I think it is essential that the alignment of the send and receive buffers match the alignment of the data types.
 
In MPI-3.1, 3.3.1 Type Matching Rule, it says
```
Type matching has to be observed at each of these three phases: 
The type of each variable in the sender buffer has to match the type specified for that entry by the send operation; 
the type specified by the send operation has to match the type specified by the receive operation; 
and the type of each variable in the receive buffer has to match the type specified for that entry by the receive operation. 
A program that fails to observe these three rules is erroneous.
```
 
This means that if you use MPI_INT, the send/receive buffer must be an int variable, and a program that uses a send/receive buffer that is not 4-byte aligned would be wrong.
 
For example, MPI_BYTE is 1 byte, so there is no problem with this test program, but in other cases, we need to multiply the size of the data type.
 
Please point out if I have misread the MPI standard.
 
I'm having a trouble with Fujitsu MPI because this is causing errors in this test, so please fix this.
