### PR TITLE
Add GPU tests for DLPack support

### DIFF
--- a/src/mpi4py/MPI/asbuffer.pxi
+++ b/src/mpi4py/MPI/asbuffer.pxi
@@ -130,6 +130,7 @@ cdef int Py27_GetBuffer(object obj, Py_buffer *view, int flags) except -1:
 
 #------------------------------------------------------------------------------
 
+include "asdlpack.pxi"
 include "asgpubuf.pxi"
 
 cdef int PyMPI_GetBuffer(object obj, Py_buffer *view, int flags) except -1:
@@ -138,6 +139,9 @@ cdef int PyMPI_GetBuffer(object obj, Py_buffer *view, int flags) except -1:
         if PY2:  return Py27_GetBuffer(obj, view, flags)
         return PyObject_GetBuffer(obj, view, flags)
     except BaseException:
+        try: return Py_GetDLPackBuffer(obj, view, flags)
+        except NotImplementedError: pass
+        except BaseException: raise
         try: return Py_GetGPUBuffer(obj, view, flags)
         except NotImplementedError: pass
         except BaseException: raise

--- a/src/mpi4py/MPI/asdlpack.pxi
+++ b/src/mpi4py/MPI/asdlpack.pxi
@@ -1,0 +1,217 @@
+#------------------------------------------------------------------------------
+
+cdef extern from * nogil:
+    ctypedef unsigned char      uint8_t
+    ctypedef unsigned short     uint16_t
+    ctypedef signed   long long int64_t
+    ctypedef unsigned long long uint64_t
+
+ctypedef enum DLDeviceType:
+    kDLCPU = 1
+    kDLCUDA = 2
+    kDLCUDAHost = 3
+    kDLOpenCL = 4
+    kDLVulkan = 7
+    kDLMetal = 8
+    kDLVPI = 9
+    kDLROCM = 10
+    kDLROCMHost = 11
+    kDLExtDev = 12
+    kDLCUDAManaged = 13
+
+ctypedef struct DLDevice:
+  DLDeviceType device_type
+  int device_id
+
+ctypedef enum DLDataTypeCode:
+    kDLInt = 0
+    kDLUInt = 1
+    kDLFloat = 2
+    kDLOpaqueHandle = 3
+    kDLBfloat = 4
+    kDLComplex = 5
+
+ctypedef struct DLDataType:
+    uint8_t code
+    uint8_t bits
+    uint16_t lanes
+
+ctypedef struct DLTensor:
+    void *data
+    DLDevice device
+    int ndim
+    DLDataType dtype
+    int64_t *shape
+    int64_t *strides
+    uint64_t byte_offset
+
+ctypedef struct DLManagedTensor:
+    DLTensor dl_tensor
+    void *manager_ctx
+    void (*deleter)(DLManagedTensor *)
+
+#------------------------------------------------------------------------------
+
+cdef extern from "Python.h":
+    void* PyCapsule_GetPointer(object, const char[]) except? NULL
+    int PyCapsule_SetName(object, const char[]) except -1
+    int PyCapsule_IsValid(object, const char[])
+
+#------------------------------------------------------------------------------
+
+cdef inline int dlpack_is_contig(const DLTensor *dltensor, char order) nogil:
+    cdef int i, ndim = dltensor.ndim
+    cdef int64_t *shape = dltensor.shape
+    cdef int64_t *strides = dltensor.strides
+    cdef int64_t start, step, index, size = 1
+    if strides == NULL:
+        if ndim > 1 and order == c'F':
+            return 0
+        return 1
+    if order == c'F':
+        start = 0
+        step = 1
+    else:
+        start = ndim - 1
+        step = -1
+    for i from 0 <= i < ndim:
+        index = start + step * i
+        if size != strides[index]:
+            return 0
+        size *= shape[index]
+    return 1
+
+cdef inline int dlpack_check_shape(const DLTensor *dltensor) except -1:
+    cdef int i, ndim = dltensor.ndim
+    if ndim < 0:
+        raise BufferError("dlpack: number of dimensions is negative")
+    if ndim > 0 and dltensor.shape == NULL:
+        raise BufferError("dlpack: shape is NULL")
+    for i from 0 <= i < ndim:
+        if dltensor.shape[i] < 0:
+            raise BufferError("dlpack: shape item is negative")
+    if dltensor.strides != NULL:
+        for i from 0 <= i < ndim:
+            if dltensor.strides[i] < 0:
+                raise BufferError("dlpack: strides item is negative")
+    return 0
+
+cdef inline int dlpack_check_contig(const DLTensor *dltensor) except -1:
+    if dltensor.strides == NULL: return 0
+    if dlpack_is_contig(dltensor, c'C'): return 0
+    if dlpack_is_contig(dltensor, c'F'): return 0
+    raise BufferError("dlpack: buffer is not contiguous")
+
+cdef inline void *dlpack_get_data(const DLTensor *dltensor) nogil:
+    return <char*> dltensor.data + dltensor.byte_offset
+
+cdef inline Py_ssize_t dlpack_get_size(const DLTensor *dltensor) nogil:
+    cdef int i, ndim = dltensor.ndim
+    cdef int64_t *shape = dltensor.shape
+    cdef Py_ssize_t bits = dltensor.dtype.bits
+    cdef Py_ssize_t lanes = dltensor.dtype.lanes
+    cdef Py_ssize_t size = 1
+    for i from 0 <= i < ndim:
+        size *= <Py_ssize_t> shape[i]
+    size *= (bits * lanes + 7) // 8
+    return size
+
+cdef inline char *dlpack_get_format(const DLTensor *dltensor) nogil:
+    cdef unsigned int code = dltensor.dtype.code
+    cdef unsigned int bits = dltensor.dtype.bits
+    if dltensor.dtype.lanes != 1: return BYTE_FMT
+    if code == kDLInt:
+        if bits == 1*8: return b"i1"
+        if bits == 2*8: return b"i2"
+        if bits == 4*8: return b"i4"
+        if bits == 8*8: return b"i8"
+    if code == kDLUInt:
+        if bits == 1*8: return b"u1"
+        if bits == 2*8: return b"u2"
+        if bits == 4*8: return b"u4"
+        if bits == 8*8: return b"u8"
+    if code == kDLFloat:
+       if bits ==  2*8: return b"f2"
+       if bits ==  4*8: return b"f4"
+       if bits ==  8*8: return b"f8"
+       if bits == 12*8: return b"f12"
+       if bits == 16*8: return b"f16"
+    if code == kDLComplex:
+       if bits ==  4*8: return b"c4"
+       if bits ==  8*8: return b"c8"
+       if bits == 16*8: return b"c16"
+       if bits == 24*8: return b"c24"
+       if bits == 32*8: return b"c32"
+    return BYTE_FMT
+
+cdef inline Py_ssize_t dlpack_get_itemsize(const DLTensor *dltensor) nogil:
+    if dltensor.dtype.lanes != 1: return 1
+    return (dltensor.dtype.bits + 7) // 8
+
+#------------------------------------------------------------------------------
+
+cdef int Py_CheckDLPackBuffer(object obj):
+    try: return <bint>hasattr(obj, '__dlpack__')
+    except: return 0
+
+cdef int Py_GetDLPackBuffer(object obj, Py_buffer *view, int flags) except -1:
+    cdef object dlpack
+    cdef object dlpack_device
+    cdef int device_type
+    cdef int device_id
+    cdef object capsule
+    cdef DLManagedTensor *managed
+    cdef const DLTensor *dltensor
+    cdef void *buf
+    cdef Py_ssize_t size
+    cdef bint readonly
+    cdef bint fixnull
+
+    try:
+        dlpack = obj.__dlpack__
+    except AttributeError:
+        raise NotImplementedError("dlpack: missing __dlpack__ method")
+
+    try:
+        dlpack_device = obj.__dlpack_device__
+    except AttributeError:
+        dlpack_device = None
+    if dlpack_device is not None:
+        device_type, device_id = dlpack_device()
+    else:
+        device_type, devide_id = kDLCPU, 0
+    if device_type == kDLCPU:
+        capsule = dlpack()
+    else:
+        capsule = dlpack(stream=-1)
+    if not PyCapsule_IsValid(capsule, b"dltensor"):
+        raise BufferError("dlpack: invalid capsule object")
+
+    managed = <DLManagedTensor*> PyCapsule_GetPointer(capsule, b"dltensor")
+    dltensor = &managed.dl_tensor
+
+    try:
+        dlpack_check_shape(dltensor)
+        dlpack_check_contig(dltensor)
+
+        buf = dlpack_get_data(dltensor)
+        size = dlpack_get_size(dltensor)
+        readonly = 0
+
+        fixnull = (buf == NULL and size == 0)
+        if fixnull: buf = &fixnull
+        PyBuffer_FillInfo(view, obj, buf, size, readonly, flags)
+        if fixnull: view.buf = NULL
+
+        if (flags & PyBUF_FORMAT) == PyBUF_FORMAT:
+            view.format = dlpack_get_format(dltensor)
+            if view.format != BYTE_FMT:
+                view.itemsize = dlpack_get_itemsize(dltensor)
+    finally:
+        if managed.deleter != NULL:
+            managed.deleter(managed)
+        PyCapsule_SetName(capsule, b"used_dltensor")
+        del capsule
+    return 0
+
+#------------------------------------------------------------------------------

--- a/src/mpi4py/MPI/asdlpack.pxi
+++ b/src/mpi4py/MPI/asdlpack.pxi
@@ -1,4 +1,5 @@
 #------------------------------------------------------------------------------
+# Below is dlpack.h (as of v0.6)
 
 cdef extern from * nogil:
     ctypedef unsigned char      uint8_t
@@ -20,8 +21,8 @@ ctypedef enum DLDeviceType:
     kDLCUDAManaged = 13
 
 ctypedef struct DLDevice:
-  DLDeviceType device_type
-  int device_id
+    DLDeviceType device_type
+    int device_id
 
 ctypedef enum DLDataTypeCode:
     kDLInt = 0
@@ -169,17 +170,11 @@ cdef int Py_GetDLPackBuffer(object obj, Py_buffer *view, int flags) except -1:
 
     try:
         dlpack = obj.__dlpack__
-    except AttributeError:
-        raise NotImplementedError("dlpack: missing __dlpack__ method")
-
-    try:
         dlpack_device = obj.__dlpack_device__
     except AttributeError:
-        dlpack_device = None
-    if dlpack_device is not None:
-        device_type, device_id = dlpack_device()
-    else:
-        device_type, devide_id = kDLCPU, 0
+        raise NotImplementedError("dlpack: missing support")
+
+    device_type, device_id = dlpack_device()
     if device_type == kDLCPU:
         capsule = dlpack()
     else:

--- a/src/mpi4py/MPI/msgbuffer.pxi
+++ b/src/mpi4py/MPI/msgbuffer.pxi
@@ -26,6 +26,9 @@ cdef inline int is_buffer(object ob):
     else:
         return PyObject_CheckBuffer(ob) or _Py2_IsBuffer(ob)
 
+cdef inline int is_dlpack_buffer(object ob):
+    return Py_CheckDLPackBuffer(ob)
+
 cdef inline int is_gpu_buffer(object ob):
     return Py_CheckGPUBuffer(ob)
 
@@ -185,6 +188,8 @@ cdef _p_message message_simple(object msg,
             (o_buf, o_count, o_displ, o_type) = msg
         else:
             raise ValueError("message: expecting 2 to 4 items")
+    elif is_dlpack_buffer(msg):
+        o_buf = msg
     elif is_gpu_buffer(msg):
         o_buf = msg
     elif PYPY:
@@ -299,6 +304,8 @@ cdef _p_message message_vector(object msg,
             (o_buf, o_counts, o_displs, o_type) = msg
         else:
             raise ValueError("message: expecting 2 to 4 items")
+    elif is_dlpack_buffer(msg):
+        o_buf = msg
     elif is_gpu_buffer(msg):
         o_buf = msg
     elif PYPY:

--- a/test/arrayimpl.py
+++ b/test/arrayimpl.py
@@ -411,10 +411,6 @@ if dlpack is not None and cupy is not None:
             else:
                 self.dev_type = dlpack.DLDeviceType.kDLCUDA
 
-        @property
-        def address(self):
-            return self.array.data.ptr
-
         def __dlpack_device__(self):
             if self.has_dlpack:
                 return self.array.__dlpack_device__()
@@ -427,6 +423,9 @@ if dlpack is not None and cupy is not None:
                 return self.array.__dlpack__(stream=-1)
             else:
                 return self.array.toDlpack()
+
+        def as_raw(self):
+            return self
 
 
 if numba is not None:

--- a/test/arrayimpl.py
+++ b/test/arrayimpl.py
@@ -240,6 +240,47 @@ if numpy is not None:
             return self.array.size
 
 
+try:
+    import dlpackimpl as dlpack
+except ImportError:
+    dlpack = None
+
+class BaseDLPackCPU(object):
+
+    def __dlpack_device__(self):
+        return (dlpack.DLDeviceType.kDLCPU, 0)
+
+    def __dlpack__(self, stream=None):
+        assert stream is None
+        capsule = dlpack.make_py_capsule(self.array)
+        return capsule
+
+    def as_raw(self):
+        return self
+
+
+if dlpack is not None and array is not None:
+
+    @add_backend
+    class DLPackArray(BaseDLPackCPU, ArrayArray):
+
+        backend = 'dlpack-array'
+
+        def __init__(self, arg, typecode, shape=None):
+            super(DLPackArray, self).__init__(arg, typecode, shape)
+
+
+if dlpack is not None and numpy is not None:
+
+    @add_backend
+    class DLPackNumPy(BaseDLPackCPU, ArrayNumPy):
+
+        backend = 'dlpack-numpy'
+
+        def __init__(self, arg, typecode, shape=None):
+            super(DLPackNumPy, self).__init__(arg, typecode, shape)
+
+
 def typestr(typecode, itemsize):
     typestr = ''
     if sys.byteorder == 'little':

--- a/test/arrayimpl.py
+++ b/test/arrayimpl.py
@@ -424,7 +424,7 @@ if dlpack is not None and cupy is not None:
         def __dlpack__(self, stream=None):
             cupy.cuda.get_current_stream().synchronize()
             if self.has_dlpack:
-                return self.array.__dlpack__(stream)
+                return self.array.__dlpack__(stream=-1)
             else:
                 return self.array.toDlpack()
 

--- a/test/dlpackimpl.py
+++ b/test/dlpackimpl.py
@@ -1,0 +1,230 @@
+import sys
+import ctypes
+try:
+    from enum import IntEnum
+except ImportError:
+    IntEnum = object
+if hasattr(sys, 'pypy_version_info'):
+    raise ImportError("unsupported on PyPy")
+
+class DLDeviceType(IntEnum):
+    kDLCPU = 1
+    kDLCUDA = 2
+    kDLCUDAHost = 3
+    kDLOpenCL = 4
+    kDLVulkan = 7
+    kDLMetal = 8
+    kDLVPI = 9
+    kDLROCM = 10
+    kDLROCMHost = 11
+    kDLExtDev = 12
+    kDLCUDAManaged = 13
+
+class DLDevice(ctypes.Structure):
+  _fields_ = [
+      ("device_type", ctypes.c_uint),
+      ("device_id", ctypes.c_int),
+  ]
+
+class DLDataTypeCode(IntEnum):
+    kDLInt = 0
+    kDLUInt = 1
+    kDLFloat = 2
+    kDLOpaqueHandle = 3
+    kDLBfloat = 4
+    kDLComplex = 5
+
+class DLDataType(ctypes.Structure):
+  _fields_ = [
+      ("code", ctypes.c_uint8),
+      ("bits", ctypes.c_uint8),
+      ("lanes", ctypes.c_uint16),
+  ]
+
+class DLTensor(ctypes.Structure):
+  _fields_ = [
+      ("data", ctypes.c_void_p),
+      ("device", DLDevice),
+      ("ndim", ctypes.c_int),
+      ("dtype", DLDataType),
+      ("shape", ctypes.POINTER(ctypes.c_int64)),
+      ("strides", ctypes.POINTER(ctypes.c_int64)),
+      ("byte_offset", ctypes.c_uint64),
+  ]
+
+DLManagedTensorDeleter = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+
+class DLManagedTensor(ctypes.Structure):
+    _fields_ = [
+    ("dl_tensor", DLTensor),
+    ("manager_ctx", ctypes.c_void_p),
+    ("deleter", DLManagedTensorDeleter),
+]
+
+pyapi = ctypes.pythonapi
+
+DLManagedTensor_p = ctypes.POINTER(DLManagedTensor)
+
+Py_IncRef = pyapi.Py_IncRef
+Py_IncRef.restype = None
+Py_IncRef.argtypes = [ctypes.py_object]
+
+Py_DecRef = pyapi.Py_DecRef
+Py_DecRef.restype = None
+Py_DecRef.argtypes = [ctypes.py_object]
+
+PyCapsule_Destructor = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+
+PyCapsule_New = pyapi.PyCapsule_New
+PyCapsule_New.restype = ctypes.py_object
+PyCapsule_New.argtypes = [ctypes.c_void_p, ctypes.c_char_p, PyCapsule_Destructor]
+
+PyCapsule_IsValid = pyapi.PyCapsule_IsValid
+PyCapsule_IsValid.restype = ctypes.c_int
+PyCapsule_IsValid.argtypes = [ctypes.py_object]
+
+PyCapsule_GetPointer = pyapi.PyCapsule_GetPointer
+PyCapsule_GetPointer.restype = ctypes.c_void_p
+PyCapsule_GetPointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
+
+PyCapsule_SetContext = pyapi.PyCapsule_SetContext
+PyCapsule_SetContext.restype = ctypes.c_int
+PyCapsule_SetContext.argtypes = [ctypes.py_object, ctypes.c_void_p]
+
+PyCapsule_GetContext = pyapi.PyCapsule_GetContext
+PyCapsule_GetContext.restype = ctypes.c_void_p
+PyCapsule_GetContext.argtypes = [ctypes.py_object]
+
+
+def make_dl_datatype(typecode, itemsize):
+    code = None
+    bits = itemsize * 8
+    lanes = 1
+    if typecode in "bhilqnp":
+        code = DLDataTypeCode.kDLInt
+    if typecode in "BHILQNP":
+        code = DLDataTypeCode.kDLUInt
+    if typecode in "efdg":
+        code = DLDataTypeCode.kDLFloat
+    if typecode in "FDG":
+        code = DLDataTypeCode.kDLComplex
+    if typecode == "G" and itemsize == 32:
+        code = DLDataTypeCode.kDLFloat
+        bits //= 2
+        lanes *= 2
+    datatype = DLDataType()
+    datatype.code = code
+    datatype.bits = bits
+    datatype.lanes = lanes
+    return datatype
+
+
+def make_dl_shape(shape, order=None, strides=None):
+    null = ctypes.cast(0, ctypes.POINTER(ctypes.c_int64))
+    if isinstance(shape, int):
+        shape = [shape]
+    ndim = len(shape)
+    if ndim == 0:
+        shape = null
+        strides = null
+    else:
+        shape = (ctypes.c_int64*ndim)(*shape)
+        if order == 'C':
+            size = 1
+            strides = []
+            for i in range(ndim-1, -1, -1):
+                strides.append(size)
+                size *= shape[i]
+            strides = (ctypes.c_int64*ndim)(*strides)
+        elif order == 'F':
+            size = 1
+            strides = []
+            for i in range(ndim):
+                strides.append(size)
+                size *= shape[i]
+            strides = (ctypes.c_int64*ndim)(*strides)
+        elif strides is not None:
+            strides = (ctypes.c_int64*ndim)(*strides)
+        else:
+            strides = null
+    return ndim, shape, strides
+
+
+def make_dl_tensor(obj):
+    try:
+        data, size = obj.buffer_info()
+        typecode = obj.typecode
+        itemsize = obj.itemsize
+    except AttributeError:
+        data = obj.ctypes.data
+        size = obj.size
+        typecode = obj.dtype.char
+        itemsize = obj.itemsize
+
+    device = DLDevice(DLDeviceType.kDLCPU, 0)
+    datatype = make_dl_datatype(typecode, itemsize)
+    ndim, shape, strides = make_dl_shape(size)
+
+    dltensor = DLTensor()
+    dltensor.data = data if size > 0 else 0
+    dltensor.device = device
+    dltensor.ndim = ndim
+    dltensor.dtype = datatype
+    dltensor.shape = shape
+    dltensor.strides = strides
+    dltensor.byte_offset = 0
+    return dltensor
+
+
+def make_dl_manager_ctx(obj):
+    py_obj = ctypes.py_object(obj)
+    if False: Py_IncRef(py_obj)
+    void_p = ctypes.c_void_p.from_buffer(py_obj)
+    return void_p
+
+
+@DLManagedTensorDeleter
+def dl_managed_tensor_deleter(void_p):
+    managed = ctypes.cast(void_p, DLManagedTensor_p)
+    manager_ctx = managed.contents.manager_ctx
+    py_obj = ctypes.cast(manager_ctx, ctypes.py_object)
+    if False: Py_DecRef(py_obj)
+
+
+def make_dl_managed_tensor(obj):
+    managed = DLManagedTensor()
+    managed.dl_tensor = make_dl_tensor(obj)
+    managed.manager_ctx = make_dl_manager_ctx(obj)
+    managed.deleter = dl_managed_tensor_deleter
+    return managed
+
+
+def make_py_context(context):
+    py_obj = ctypes.py_object(context)
+    Py_IncRef(py_obj)
+    context = ctypes.c_void_p.from_buffer(py_obj)
+    return ctypes.c_void_p(context.value)
+
+
+@PyCapsule_Destructor
+def py_capsule_destructor(void_p):
+    capsule = ctypes.cast(void_p, ctypes.py_object)
+    if PyCapsule_IsValid(capsule, b"dltensor"):
+        pointer = PyCapsule_GetPointer(capsule, b"dltensor")
+        managed = ctypes.cast(pointer, DLManagedTensor_p)
+        deleter = managed.contents.deleter
+        if deleter:
+            deleter(managed)
+    context = PyCapsule_GetContext(capsule)
+    managed = ctypes.cast(context, ctypes.py_object)
+    Py_DecRef(managed)
+
+
+def make_py_capsule(managed):
+    if not isinstance(managed, DLManagedTensor):
+        managed = make_dl_managed_tensor(managed)
+    pointer = ctypes.pointer(managed)
+    capsule = PyCapsule_New(pointer, b"dltensor", py_capsule_destructor)
+    context = make_py_context(managed)
+    PyCapsule_SetContext(capsule, context)
+    return capsule

--- a/test/mpiunittest.py
+++ b/test/mpiunittest.py
@@ -92,7 +92,7 @@ def mpi_predicate(predicate):
     return None
 
 def is_mpi_gpu(predicate, array):
-    if array.backend in ('cupy', 'numba'):
+    if array.backend in ('cupy', 'numba', 'dlpack-cupy'):
         if mpi_predicate(predicate):
             return True
     return False

--- a/test/test_msgspec.py
+++ b/test/test_msgspec.py
@@ -68,10 +68,10 @@ try:
 except ImportError:
     dlpack = None
 
-class DLPackBuf(BaseBuf):
+class DLPackCPUBuf(BaseBuf):
 
     def __init__(self, typecode, initializer):
-        super(DLPackBuf, self).__init__(typecode, initializer)
+        super(DLPackCPUBuf, self).__init__(typecode, initializer)
         self.managed = dlpack.make_dl_managed_tensor(self._buf)
 
     def __del__(self):
@@ -425,11 +425,11 @@ class TestMessageSimpleNumPy(unittest.TestCase,
 
 @unittest.skipIf(array is None, 'array')
 @unittest.skipIf(dlpack is None, 'dlpack')
-class TestMessageSimpleDLPackBuf(unittest.TestCase,
+class TestMessageSimpleDLPackCPUBuf(unittest.TestCase,
                                  BaseTestMessageSimpleArray):
 
     def array(self, typecode, initializer):
-        return DLPackBuf(typecode, initializer)
+        return DLPackCPUBuf(typecode, initializer)
 
 
 @unittest.skipIf(array is None, 'array')
@@ -518,10 +518,10 @@ class TestMessageSimpleNumba(unittest.TestCase,
 
 @unittest.skipIf(array is None, 'array')
 @unittest.skipIf(dlpack is None, 'dlpack')
-class TestMessageDLPackBuf(unittest.TestCase):
+class TestMessageDLPackCPUBuf(unittest.TestCase):
 
     def testDevice(self):
-        buf = DLPackBuf('i', [0,1,2,3])
+        buf = DLPackCPUBuf('i', [0,1,2,3])
         buf.__dlpack_device__ = None
         self.assertRaises(TypeError, MPI.Get_address, buf)
         buf.__dlpack_device__ = lambda: None
@@ -538,7 +538,7 @@ class TestMessageDLPackBuf(unittest.TestCase):
         MPI.Get_address(buf)
 
     def testCapsule(self):
-        buf = DLPackBuf('i', [0,1,2,3])
+        buf = DLPackCPUBuf('i', [0,1,2,3])
         #
         capsule = buf.__dlpack__()
         MPI.Get_address(buf)
@@ -558,7 +558,7 @@ class TestMessageDLPackBuf(unittest.TestCase):
         del buf.__dlpack__
 
     def testNdim(self):
-        buf = DLPackBuf('i', [0,1,2,3])
+        buf = DLPackCPUBuf('i', [0,1,2,3])
         dltensor = buf.managed.dl_tensor
         #
         for ndim in (2, 1, 0):
@@ -571,7 +571,7 @@ class TestMessageDLPackBuf(unittest.TestCase):
         del dltensor
 
     def testShape(self):
-        buf = DLPackBuf('i', [0,1,2,3])
+        buf = DLPackCPUBuf('i', [0,1,2,3])
         dltensor = buf.managed.dl_tensor
         #
         dltensor.ndim = 1
@@ -589,7 +589,7 @@ class TestMessageDLPackBuf(unittest.TestCase):
         del dltensor
 
     def testStrides(self):
-        buf = DLPackBuf('i', range(8))
+        buf = DLPackCPUBuf('i', range(8))
         dltensor = buf.managed.dl_tensor
         #
         for order in ('C', 'F'):
@@ -602,7 +602,7 @@ class TestMessageDLPackBuf(unittest.TestCase):
         del dltensor
 
     def testContiguous(self):
-        buf = DLPackBuf('i', range(8))
+        buf = DLPackCPUBuf('i', range(8))
         dltensor = buf.managed.dl_tensor
         #
         dltensor.ndim, dltensor.shape, dltensor.strides = \
@@ -622,7 +622,7 @@ class TestMessageDLPackBuf(unittest.TestCase):
         del dltensor
 
     def testByteOffset(self):
-        buf = DLPackBuf('B', [0,1,2,3])
+        buf = DLPackCPUBuf('B', [0,1,2,3])
         dltensor = buf.managed.dl_tensor
         #
         dltensor.ndim = 1

--- a/test/test_msgspec.py
+++ b/test/test_msgspec.py
@@ -93,10 +93,10 @@ class DLPackBuf(BaseBuf):
 
 # ---
 
-class GPUBuf(BaseBuf):
+class CAIBuf(BaseBuf):
 
     def __init__(self, typecode, initializer, readonly=False):
-        super(GPUBuf, self).__init__(typecode, initializer)
+        super(CAIBuf, self).__init__(typecode, initializer)
         address = self._buf.buffer_info()[0]
         typecode = self._buf.typecode
         itemsize = self._buf.itemsize
@@ -433,11 +433,11 @@ class TestMessageSimpleDLPackBuf(unittest.TestCase,
 
 
 @unittest.skipIf(array is None, 'array')
-class TestMessageSimpleGPUBuf(unittest.TestCase,
+class TestMessageSimpleCAIBuf(unittest.TestCase,
                               BaseTestMessageSimpleArray):
 
     def array(self, typecode, initializer):
-        return GPUBuf(typecode, initializer)
+        return CAIBuf(typecode, initializer)
 
 
 @unittest.skipIf(cupy is None, 'cupy')
@@ -636,61 +636,61 @@ class TestMessageDLPackBuf(unittest.TestCase):
 # ---
 
 @unittest.skipIf(array is None, 'array')
-class TestMessageGPUBufInterface(unittest.TestCase):
+class TestMessageCAIBuf(unittest.TestCase):
 
     def testNonReadonly(self):
-        smsg = GPUBuf('i', [1,2,3], readonly=True)
-        rmsg = GPUBuf('i', [0,0,0], readonly=True)
+        smsg = CAIBuf('i', [1,2,3], readonly=True)
+        rmsg = CAIBuf('i', [0,0,0], readonly=True)
         self.assertRaises(BufferError, Sendrecv, smsg, rmsg)
 
     def testNonContiguous(self):
-        smsg = GPUBuf('i', [1,2,3])
-        rmsg = GPUBuf('i', [0,0,0])
+        smsg = CAIBuf('i', [1,2,3])
+        rmsg = CAIBuf('i', [0,0,0])
         strides = rmsg.__cuda_array_interface__['strides']
         bad_strides = strides[:-1] + (7,)
         rmsg.__cuda_array_interface__['strides'] = bad_strides
         self.assertRaises(BufferError, Sendrecv, smsg, rmsg)
 
     def testAttrNone(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__ = None
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testAttrEmpty(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__ = dict()
         self.assertRaises(KeyError, Sendrecv, smsg, rmsg)
 
     def testAttrType(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         items = list(rmsg.__cuda_array_interface__.items())
         rmsg.__cuda_array_interface__ = items
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testDataMissing(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         del rmsg.__cuda_array_interface__['data']
         self.assertRaises(KeyError, Sendrecv, smsg, rmsg)
 
     def testDataNone(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['data'] = None
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testDataType(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['data'] = 0
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testDataValue(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         dev_ptr = rmsg.__cuda_array_interface__['data'][0]
         rmsg.__cuda_array_interface__['data'] = (dev_ptr, )
         self.assertRaises(ValueError, Sendrecv, smsg, rmsg)
@@ -700,99 +700,99 @@ class TestMessageGPUBufInterface(unittest.TestCase):
         self.assertRaises(ValueError, Sendrecv, smsg, rmsg)
 
     def testTypestrMissing(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         del rmsg.__cuda_array_interface__['typestr']
         self.assertRaises(KeyError, Sendrecv, smsg, rmsg)
 
     def testTypestrNone(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['typestr'] = None
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testTypestrType(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['typestr'] = 42
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testTypestrItemsize(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         typestr = rmsg.__cuda_array_interface__['typestr']
         rmsg.__cuda_array_interface__['typestr'] = typestr[:2]+'X'
         self.assertRaises(ValueError, Sendrecv, smsg, rmsg)
 
     def testShapeMissing(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         del rmsg.__cuda_array_interface__['shape']
         self.assertRaises(KeyError, Sendrecv, smsg, rmsg)
 
     def testShapeNone(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['shape'] = None
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testShapeType(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['shape'] = 3
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testShapeValue(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['shape'] = (3, -1)
         rmsg.__cuda_array_interface__['strides'] = None
         self.assertRaises(BufferError, Sendrecv, smsg, rmsg)
 
     def testStridesMissing(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         del rmsg.__cuda_array_interface__['strides']
         Sendrecv(smsg, rmsg)
         self.assertEqual(smsg, rmsg)
 
     def testStridesNone(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['strides'] = None
         Sendrecv(smsg, rmsg)
         self.assertEqual(smsg, rmsg)
 
     def testStridesType(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['strides'] = 42
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testDescrMissing(self):
-        smsg = GPUBuf('d', [1,2,3])
-        rmsg = GPUBuf('d', [0,0,0])
+        smsg = CAIBuf('d', [1,2,3])
+        rmsg = CAIBuf('d', [0,0,0])
         del rmsg.__cuda_array_interface__['descr']
         Sendrecv(smsg, rmsg)
         self.assertEqual(smsg, rmsg)
 
     def testDescrNone(self):
-        smsg = GPUBuf('d', [1,2,3])
-        rmsg = GPUBuf('d', [0,0,0])
+        smsg = CAIBuf('d', [1,2,3])
+        rmsg = CAIBuf('d', [0,0,0])
         rmsg.__cuda_array_interface__['descr'] = None
         Sendrecv(smsg, rmsg)
         self.assertEqual(smsg, rmsg)
 
     def testDescrType(self):
-        smsg = GPUBuf('B', [1,2,3])
-        rmsg = GPUBuf('B', [0,0,0])
+        smsg = CAIBuf('B', [1,2,3])
+        rmsg = CAIBuf('B', [0,0,0])
         rmsg.__cuda_array_interface__['descr'] = 42
         self.assertRaises(TypeError, Sendrecv, smsg, rmsg)
 
     def testDescrWarning(self):
         m, n = 5, 3
-        smsg = GPUBuf('d', list(range(m*n)))
-        rmsg = GPUBuf('d', [0]*(m*n))
+        smsg = CAIBuf('d', list(range(m*n)))
+        rmsg = CAIBuf('d', [0]*(m*n))
         typestr = rmsg.__cuda_array_interface__['typestr']
         itemsize = int(typestr[2:])
         new_typestr = "|V"+str(itemsize*n)
@@ -1030,11 +1030,11 @@ class TestMessageVectorNumPy(unittest.TestCase,
 
 
 @unittest.skipIf(array is None, 'array')
-class TestMessageVectorGPUBuf(unittest.TestCase,
+class TestMessageVectorCAIBuf(unittest.TestCase,
                               BaseTestMessageVectorArray):
 
     def array(self, typecode, initializer):
-        return GPUBuf(typecode, initializer)
+        return CAIBuf(typecode, initializer)
 
 
 @unittest.skipIf(cupy is None, 'cupy')
@@ -1128,9 +1128,9 @@ class TestMessageVectorW(unittest.TestCase):
         self.assertTrue((sbuf == rbuf).all())
 
     @unittest.skipIf(array is None, 'array')
-    def testMessageGPUBuf(self):
-        sbuf = GPUBuf('i', [1,2,3], readonly=True)
-        rbuf = GPUBuf('i', [0,0,0], readonly=False)
+    def testMessageCAIBuf(self):
+        sbuf = CAIBuf('i', [1,2,3], readonly=True)
+        rbuf = CAIBuf('i', [0,0,0], readonly=False)
         smsg = [sbuf, [3], [0], [MPI.INT]]
         rmsg = [rbuf, ([3], [0]), [MPI.INT]]
         Alltoallw(smsg, rmsg)
@@ -1263,9 +1263,9 @@ class TestMessageRMA(unittest.TestCase):
 
     @unittest.skipMPI('msmpi')
     @unittest.skipIf(array is None, 'array')
-    def testMessageGPUBuf(self):
-        sbuf = GPUBuf('i', [1,2,3], readonly=True)
-        rbuf = GPUBuf('i', [0,0,0], readonly=False)
+    def testMessageCAIBuf(self):
+        sbuf = CAIBuf('i', [1,2,3], readonly=True)
+        rbuf = CAIBuf('i', [0,0,0], readonly=False)
         PutGet(sbuf, rbuf)
         self.assertEqual(sbuf, rbuf)
 

--- a/test/test_msgspec.py
+++ b/test/test_msgspec.py
@@ -523,7 +523,7 @@ class TestMessageDLPackBuf(unittest.TestCase):
     def testDevice(self):
         buf = DLPackBuf('i', [0,1,2,3])
         buf.__dlpack_device__ = None
-        MPI.Get_address(buf)
+        self.assertRaises(TypeError, MPI.Get_address, buf)
         buf.__dlpack_device__ = lambda: None
         self.assertRaises(TypeError, MPI.Get_address, buf)
         buf.__dlpack_device__ = lambda: (None, 0)


### PR DESCRIPTION
DO NOT MERGE. To be continued tomorrow...

With Open MPI 4.1.1, I am seeing `MPI_ERR_TRUNCATE` in `testAllgatherv3`, so I skip them for now:
```
$ mpirun --mca opal_cuda_support 1 -n 1 python test/runtests.py --no-numba --cupy -e "test_cco_nb_vec" -e "test_cco_vec"
```
Tomorrow I will continue investigating the only errors in `test_msgspec.py`.