### PR TITLE
Allow adding an optional local version to the package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,12 @@ def version():
     srcdir = os.path.join(topdir, 'src')
     with open(os.path.join(srcdir, 'mpi4py', '__init__.py')) as f:
         m = re.search(r"__version__\s*=\s*'(.*)'", f.read())
-        return m.groups()[0]
+    public_version = m.groups()[0]
+    local_version = os.environ.get('MPI4PY_LOCAL_VERSION')
+    if local_version:
+        return '{0}+{1}'.format(public_version, local_version)
+    else:
+        return public_version
 
 def description():
     with open(os.path.join(topdir, 'DESCRIPTION.rst')) as f:


### PR DESCRIPTION
This is a rework of PR #113, this time based on branch `maint` and incorporating @dalcinl's suggestion to fully ignore `MPI4PY_LOCAL_VERSION` if it's set to an empty value.

-----

Hi,

we would like to build several variations of the same version of mpi4py and host them on an internal repository. It would be great to be able to add a local version to the package version so we can (1) make sure that we install the local binary package and not the public package and (2) distinguish between mpi4py binaries built for, e.g., multiple versions of MPI.

With this PR users can optionally define an environment variable `MPI4PY_LOCAL_VERSION` to append a local version identifier. They could follow the conventions lined out in https://www.python.org/dev/peps/pep-0440/#local-version-identifiers.