### PR TITLE
mpi4py.util.pkl5: ssend() paired with mprobe() is doomed to deadlock

### DIFF
--- a/src/mpi4py/util/pkl5.py
+++ b/src/mpi4py/util/pkl5.py
@@ -558,7 +558,8 @@ class Comm(MPI.Comm):
 
     def ssend(self, obj, dest, tag=0):
         """Blocking send in synchronous mode."""
-        _send(self, MPI.Comm.Ssend, obj, dest, tag)
+        sreq = _isend(self, MPI.Comm.Issend, obj, dest, tag)
+        MPI.Request.Waitall(sreq)
 
     def isend(self, obj, dest, tag=0):
         """Nonblocking send in standard mode."""

--- a/test/test_util_pkl5.py
+++ b/test/test_util_pkl5.py
@@ -571,6 +571,26 @@ class BaseTest(object):
         finally:
             comm.Free()
 
+    def testSSendAndMProbe(self):
+        comm = self.COMM.Dup()
+        size = self.COMM.Get_size()
+        rank = self.COMM.Get_rank()
+        if size == 1: return
+        try:
+            for smess in messages:
+                if rank == 0:
+                    comm.ssend(smess, 1)
+                    message = comm.mprobe(1)
+                    rmess = message.recv()
+                    self.assertEqual(rmess, smess)
+                if rank == 1:
+                    message = comm.mprobe(0)
+                    rmess = message.recv()
+                    comm.ssend(rmess, 0)
+                    self.assertEqual(rmess, smess)
+        finally:
+            comm.Free()
+
     def testRequest(self):
         req = self.RequestType()
         self.assertFalse(req)


### PR DESCRIPTION
Use MPI.Comm.Issend() instead and wait for all the requests.