### PR TITLE
allow IPv6 sockets in test_dynproc.py testJoin

### DIFF
--- a/test/test_dynproc.py
+++ b/test/test_dynproc.py
@@ -164,14 +164,27 @@ class TestDPM(unittest.TestCase):
         size = MPI.COMM_WORLD.Get_size()
         rank = MPI.COMM_WORLD.Get_rank()
         server = client = address = None
-        # crate server/client sockets
+        host = socket.gethostname()
+        addresses = socket.getaddrinfo(host, None, 0, socket.SOCK_STREAM)
+        address_families = [ a[0] for a in addresses ]
+        # if both INET and INET6 are available, don't assume the order
+        # is the same on both server and client. Select INET if available.
+        if socket.AF_INET in address_families:
+            socket_family = socket.AF_INET
+        elif socket.AF_INET6 in address_families:
+            socket_family = socket.AF_INET6
+        elif address_families:
+            # allow for AF_UNIX (or other families)
+            socket_family = address_families[0]
+        else:
+            self.skipTest("socket")
+        # create server/client sockets
         if rank == 0: # server
-            server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            host = socket.gethostname()
+            server = socket.socket(socket_family, socket.SOCK_STREAM)
             server.bind((host, 0))
             server.listen(0)
         if rank == 1: # client
-            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client = socket.socket(socket_family, socket.SOCK_STREAM)
         # communicate address
         if rank == 0:
             address = server.getsockname()


### PR DESCRIPTION
Don't assume IPv4 sockets are available in TestDPM.testJoin
(test_dynproc.py). Instead, use the family reported available by
socket.getaddrinfo().

Use INET (IPv4) by default if available, otherwise INET6 (IPv6) or
UNIX sockets. An undocumented socket family will also be used if no
other is available.

Intended to enable testJoin to pass on IPv6-only networks.

Fixes #240.