### PR TITLE
build: Intel MPI and Python DLL search path on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,15 +236,21 @@ jobs:
         mpi:
           - mpich
           - openmpi
-        py:
-          - 3
+          - intelmpi
+        exclude:
+          - os:  macos-12
+            mpi: intelmpi
+          - os:  macos-11
+            mpi: intelmpi
         include:
-           - os: windows-2022
-             mpi: msmpi
-             py: 3
-           - os: windows-2019
-             mpi: msmpi
-             py: 3
+          - os:  windows-2022
+            mpi: intelmpi
+          - os:  windows-2019
+            mpi: intelmpi
+          - os:  windows-2022
+            mpi: msmpi
+          - os:  windows-2019
+            mpi: msmpi
 
     steps:
 
@@ -256,10 +262,10 @@ jobs:
       with:
         mpi: ${{ matrix.mpi }}
 
-    - name: Use Python ${{ matrix.py }}
+    - name: Setup Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.py }}
+        python-version: 3
 
     - name: Install packaging tools
       run:  python -m pip install build
@@ -271,16 +277,18 @@ jobs:
         MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
 
     - name: Install wheel
-      run:  python -m pip install --no-index --find-links=dist mpi4py
+      run:  python -m pip install mpi4py
+              --verbose --no-index --find-links=dist
 
-    - name: Test wheel after install
-      run:  mpiexec -n 1 python test/test_package.py
+    - name: Test wheel after install (test_package)
+      run:  mpiexec -n 1 python test/main.py test_package
 
-    - name: Test wheel after install
+    - name: Test wheel after install (helloworld)
       run:  mpiexec -n 2 python -m mpi4py.bench helloworld
 
     - name: Uninstall wheel after testing
-      run:  python -m pip uninstall --yes mpi4py
+      run:  python -m pip uninstall mpi4py
+              --verbose --yes
 
     - name: Upload wheel
       uses: actions/upload-artifact@v3

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include setup*.py *.toml *.cfg *.rst
 
 recursive-include demo *.py *.txt *.pyx *.i *.h *.c *.cxx *.f90 *.f08
 recursive-include demo [M,m]akefile *.sh python-config
-recursive-include conf *.py *.sh *.bat *.txt *.conf *.ini *.h
+recursive-include conf *.py *.sh *.pth *.txt *.conf *.ini *.h
 recursive-include src  *.py py.typed *.pyi *.pyx *.px[di]
 recursive-include src  *.h *.c *.i CMakeLists.txt
 recursive-include test *.py *.sh

--- a/conf/intelmpi.pth
+++ b/conf/intelmpi.pth
@@ -1,0 +1,7 @@
+# Add Intel MPI to Python 3.8+ DLL search path on Windows
+import os; I_MPI_ROOT = os.getenv('I_MPI_ROOT')
+import os; library_kind = os.getenv('library_kind') or 'release'
+import os; add_dll_directory = getattr(os, 'add_dll_directory', None)
+import os; d = I_MPI_ROOT and os.path.join(I_MPI_ROOT, 'bin', library_kind)
+import os; d = d and os.path.exists(d) and os.path.isdir(d) and d
+import os; d and add_dll_directory and add_dll_directory(d)

--- a/conf/mpiconfig.py
+++ b/conf/mpiconfig.py
@@ -165,7 +165,8 @@ class Config:
         if not os.path.isdir(mpi_dir):
             mpi_dir = I_MPI_ROOT
         IMPI_INC = os.path.join(mpi_dir, 'include')
-        for libdir in (('lib', 'release'), ('lib',)):
+        lib_kind = os.environ.get('library_kind') or 'release'
+        for libdir in (('lib', lib_kind), ('lib',)):
             IMPI_LIB = os.path.join(mpi_dir, *libdir)
             library = os.path.join(IMPI_LIB, 'impi.lib')
             if os.path.exists(library):

--- a/conf/mpidistutils.py
+++ b/conf/mpidistutils.py
@@ -1116,6 +1116,24 @@ class build_ext(cmd_build_ext.build_ext):
             log.info("writing %s", mpi_cfg)
             if not self.dry_run:
                 self.config.dump(filename=mpi_cfg)
+        #
+        if ext.name == 'mpi4py.MPI' and sys.platform == 'win32':
+            config_cmd = self.get_finalized_command('config')
+            with capture_stderr():
+                headers = ['stdlib.h', 'mpi.h']
+                intelmpi = config_cmd.check_macro('I_MPI_VERSION', headers)
+            if intelmpi:
+                confdir = os.path.dirname(__file__)
+                pthfile = 'intelmpi.pth'
+                source = os.path.join(confdir, pthfile)
+                target = os.path.join(self.build_lib, pthfile)
+                if os.path.exists(source):
+                    log.info("writing %s", target)
+                    copy_file(
+                        source, target,
+                        verbose=False,
+                        dry_run=self.dry_run,
+                    )
 
     def copy_extensions_to_source(self):
         build_py = self.get_finalized_command('build_py')
@@ -1142,6 +1160,11 @@ class build_ext(cmd_build_ext.build_ext):
                 dest_dir = os.path.join(self.build_lib, dirname)
                 output_file = os.path.join(dest_dir, 'mpi.cfg')
                 outputs.append(output_file)
+            if ext.name == 'mpi4py.MPI' and sys.platform == 'win32':
+                pthfile = 'intelmpi.pth'
+                output_file = os.path.join(self.build_lib, pthfile)
+                if os.path.exists(output_file):
+                    outputs.append(output_file)
         return outputs
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ Python bindings for MPI
 import os
 import sys
 import glob
-import shlex
 
 topdir = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(topdir, 'conf'))
@@ -290,6 +289,10 @@ def run_skbuild():
         cmake_source_dir = 'src/mpi4py',
     )
     metadata.update(metadata_extra)
+    #
+    package_info['package_data']['mpi4py'].append('../*.pth')
+    builder_args['cmake_process_manifest_hook'] = \
+        lambda fl: [f for f in fl if not f.endswith('.pth')]
     #
     setup_args = dict(i for d in (
         metadata,

--- a/src/mpi4py/CMakeLists.txt
+++ b/src/mpi4py/CMakeLists.txt
@@ -12,6 +12,17 @@ get_filename_component(TOPDIR ${SRCDIR} DIRECTORY)
 set(SKBUILD "${SKBUILD}")
 
 
+# intelmpi.pth
+include(CheckSymbolExists)
+set(CMAKE_REQUIRED_INCLUDES ${MPI_C_INCLUDE_PATH})
+check_symbol_exists(I_MPI_VERSION "mpi.h" HAVE_I_MPI_VERSION)
+if (HAVE_I_MPI_VERSION AND WIN32)
+  set(intelmpi.pth "${BINDIR}/intelmpi.pth")
+  configure_file(${TOPDIR}/conf/intelmpi.pth ${intelmpi.pth} COPYONLY)
+  install(FILES ${intelmpi.pth} DESTINATION src)
+endif()
+
+
 # mpi4py/mpi.cfg
 set(mpi.cfg "${BINDIR}/mpi.cfg")
 set(config "[mpi]\n")


### PR DESCRIPTION
Since Python 3.8, Windows DLLs are no longer searched in the `PATH` environment variable. While I understand the rationale behind this change, they should have introduced a new environment variable, let say `PYTHONDLLPATH`, to easily add to the search path. Otherwise, the only way is to use `os.add_dll_directory()` programatically.

Intel MPI does not install DLLs in system locations but the `I_MPI_ROOT` install tree. Moreover, the package installs two DLLs, one for debug and another for release. Users typically pick the one they want by running `setvars.bat`, and that batch script simply modifies `PATH`. But Python no longer uses `PATH` for DLL search. So here we are.

A quick and dirty workaround is to install a *.pth file in site-packages that will first look for `I_MPI_ROOT` defined in the environment, and if found, then call `os.add_dll_directory()` adding the `I_MPI_ROOT\bin\{debug|release}` directory to the DLL search path.