### PR TITLE
build: Simplify and enhance support for multiple build backends

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -76,6 +76,12 @@ jobs:
         MPI4PY_BUILD_BACKEND: skbuild
         MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
 
+    - name: Upload wheel
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpi4py-skbuild-${{ matrix.os }}
+        path: dist/mpi4py-*.whl
+
     - name: Install wheel
       run:  python -m pip install mpi4py
               --verbose --no-index --find-links=dist
@@ -90,13 +96,24 @@ jobs:
       run:  python -m pip uninstall mpi4py
               --verbose --yes
 
-    - name: Upload wheel
-      uses: actions/upload-artifact@v3
-      with:
-        name: mpi4py-skbuild-${{ matrix.os }}
-        path: dist/mpi4py-*.whl
+    - name: Install package (pip)
+      run:  python -m pip install .
+              --verbose
+      env:
+        MPI4PY_BUILD_BACKEND: skbuild
+        MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
 
-  meson:
+    - name: Test package after install (test_package)
+      run:  mpiexec -n 1 python test/main.py test_package
+
+    - name: Test package after install (helloworld)
+      run:  mpiexec -n 2 python -m mpi4py.bench helloworld
+
+    - name: Uninstall package after testing
+      run:  python -m pip uninstall mpi4py
+              --verbose --yes
+
+  mesonpy:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -137,8 +154,14 @@ jobs:
     - name: Build sdist and wheel
       run:  python -m build
       env:
+        MPI4PY_BUILD_BACKEND: mesonpy
         MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
-        CC: mpicc
+
+    - name: Upload wheel
+      uses: actions/upload-artifact@v3
+      with:
+        name: mpi4py-meson-${{ matrix.os }}
+        path: dist/mpi4py-*.whl
 
     - name: Install wheel
       run:  python -m pip install mpi4py
@@ -154,8 +177,19 @@ jobs:
       run:  python -m pip uninstall mpi4py
               --verbose --yes
 
-    - name: Upload wheel
-      uses: actions/upload-artifact@v3
-      with:
-        name: mpi4py-meson-${{ matrix.os }}
-        path: dist/mpi4py-*.whl
+    - name: Install package (pip)
+      run:  python -m pip install .
+              --verbose
+      env:
+        MPI4PY_BUILD_BACKEND: mesonpy
+        MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
+
+    - name: Test package after install (test_package)
+      run:  mpiexec -n 1 python test/main.py test_package
+
+    - name: Test package after install (helloworld)
+      run:  mpiexec -n 2 python -m mpi4py.bench helloworld
+
+    - name: Uninstall package after testing
+      run:  python -m pip uninstall mpi4py
+              --verbose --yes

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,39 +23,53 @@ permissions:
 
 jobs:
 
-  skbuild:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        backend:
+          - skbuild
+          - mesonpy
         os:
           - ubuntu-22.04
           - ubuntu-20.04
           - macos-12
           - macos-11
+          - windows-2022
+          - windows-2019
         mpi:
           - mpich
           - openmpi
           - intelmpi
         exclude:
+          - backend: mesonpy
+            os:  windows-2022
+          - backend: mesonpy
+            os:  windows-2019
           - os:  macos-12
             mpi: intelmpi
           - os:  macos-11
             mpi: intelmpi
-        include:
           - os:  windows-2022
-            mpi: intelmpi
-          - os:  windows-2019
-            mpi: intelmpi
+            mpi: mpich
           - os:  windows-2022
-            mpi: msmpi
+            mpi: openmpi
           - os:  windows-2019
-            mpi: msmpi
+            mpi: mpich
+          - os:  windows-2019
+            mpi: openmpi
 
     steps:
 
     - name: Checkout
       uses: actions/checkout@v3
+
+    #- name: Setup MSVC
+    #  if:   matrix.backend == 'mesonpy' && runner.os == 'Windows'
+    #  uses: bus1/cabuild/action/msdevshell@v1
+    #  with:
+    #    architecture: x64
 
     - name: Setup MPI (${{ matrix.mpi }})
       uses: mpi4py/setup-mpi@v1
@@ -70,16 +84,16 @@ jobs:
     - name: Install Python packages (build)
       run:  python -m pip install build
 
-    - name: Build sdist and wheel
+    - name: Build sdist and wheel (${{ matrix.backend }})
       run:  python -m build
       env:
-        MPI4PY_BUILD_BACKEND: skbuild
+        MPI4PY_BUILD_BACKEND: ${{ matrix.backend }}
         MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
 
     - name: Upload wheel
       uses: actions/upload-artifact@v3
       with:
-        name: mpi4py-skbuild-${{ matrix.os }}
+        name: mpi4py-${{ matrix.backend }}-${{ matrix.os }}
         path: dist/mpi4py-*.whl
 
     - name: Install wheel
@@ -96,92 +110,11 @@ jobs:
       run:  python -m pip uninstall mpi4py
               --verbose --yes
 
-    - name: Install package (pip)
+    - name: Install package with pip (${{ matrix.backend }})
       run:  python -m pip install .
               --verbose
       env:
-        MPI4PY_BUILD_BACKEND: skbuild
-        MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
-
-    - name: Test package after install (test_package)
-      run:  mpiexec -n 1 python test/main.py test_package
-
-    - name: Test package after install (helloworld)
-      run:  mpiexec -n 2 python -m mpi4py.bench helloworld
-
-    - name: Uninstall package after testing
-      run:  python -m pip uninstall mpi4py
-              --verbose --yes
-
-  mesonpy:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-22.04
-          - ubuntu-20.04
-          - macos-12
-          - macos-11
-        mpi:
-          - mpich
-          - openmpi
-          - intelmpi
-        exclude:
-          - os:  macos-12
-            mpi: intelmpi
-          - os:  macos-11
-            mpi: intelmpi
-
-    steps:
-
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Setup MPI (${{ matrix.mpi }})
-      uses: mpi4py/setup-mpi@v1
-      with:
-        mpi: ${{ matrix.mpi }}
-
-    - name: Setup Python (${{ github.event.inputs.py || 3 }})
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ github.event.inputs.py || 3 }}
-
-    - name: Install Python packages (build)
-      run:  python -m pip install build
-
-    - name: Build sdist and wheel
-      run:  python -m build
-      env:
-        MPI4PY_BUILD_BACKEND: mesonpy
-        MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
-
-    - name: Upload wheel
-      uses: actions/upload-artifact@v3
-      with:
-        name: mpi4py-meson-${{ matrix.os }}
-        path: dist/mpi4py-*.whl
-
-    - name: Install wheel
-      run:  python -m pip install mpi4py
-              --verbose --no-index --find-links=dist
-
-    - name: Test wheel after install (test_package)
-      run:  mpiexec -n 1 python test/main.py test_package
-
-    - name: Test wheel after install (helloworld)
-      run:  mpiexec -n 2 python -m mpi4py.bench helloworld
-
-    - name: Uninstall wheel after testing
-      run:  python -m pip uninstall mpi4py
-              --verbose --yes
-
-    - name: Install package (pip)
-      run:  python -m pip install .
-              --verbose
-      env:
-        MPI4PY_BUILD_BACKEND: mesonpy
+        MPI4PY_BUILD_BACKEND: ${{ matrix.backend }}
         MPI4PY_LOCAL_VERSION: ${{ matrix.mpi }}
 
     - name: Test package after install (test_package)

--- a/conf/builder.py
+++ b/conf/builder.py
@@ -1,12 +1,38 @@
-import os
 import contextlib
-import setuptools.build_meta as _st_bm
+import importlib
+import os
+import shutil
 
+# ---
+
+
+def setup_env_mpicc():
+    mpicc = shutil.which('mpicc')
+    mpicc = os.environ.get('MPICC', mpicc)
+    mpicc = os.environ.get('MPI4PY_BUILD_MPICC', mpicc)
+    if not mpicc:
+        return
+    if ' ' in mpicc:
+        mpicc = f'"{mpicc}"'
+    if 'CC' not in os.environ:
+        os.environ['CC'] =  mpicc
+
+
+# ---
 
 def get_backend_name(default='default'):
-    return os.environ.get(
-        'MPI4PY_BUILD_BACKEND', default
+    name = os.environ.get(
+        'MPI4PY_BUILD_BACKEND', default,
     ).lower().replace('_', '-')
+    if name in ('default', ''):
+        return 'setuptools'
+    if name in ('setuptools', 'setup'):
+        return 'setuptools'
+    if name in ('scikit-build', 'skbuild', 'cmake'):
+        return 'scikit-build'
+    if name in ('meson-python', 'mesonpy', 'meson'):
+        return 'meson-python'
+    raise RuntimeError(f"Unknown build backend {name!r}")
 
 
 def read_build_requires(package):
@@ -16,22 +42,32 @@ def read_build_requires(package):
         return [req for req in map(str.strip, f) if req]
 
 
-def get_build_requires():
+def get_requires_for_build(dist):
     name = get_backend_name()
-    use_skbuild = name in ('scikit-build', 'skbuild')
-    requires = read_build_requires('cython')
-    if use_skbuild:
-        for req in read_build_requires('skbuild'):
-            requires.append(req)
+    requires = []
+    if dist == 'wheel':
+        if name == 'scikit-build':
+            requires += read_build_requires('skbuild')
+        if name == 'meson-python':
+            requires += read_build_requires('mesonpy')
+    if dist in ('wheel', 'editable'):
+        requires += read_build_requires('cython')
     return requires
 
 
 @contextlib.contextmanager
-def set_build_backend(name='default'):
+def build_backend(name='default'):
     name_saved = os.environ.get('MPI4PY_BUILD_BACKEND')
+    os.environ['MPI4PY_BUILD_BACKEND'] = name
     try:
-        os.environ['MPI4PY_BUILD_BACKEND'] = name
-        yield _st_bm
+        name = get_backend_name()
+        if name == 'setuptools':
+            yield importlib.import_module('setuptools.build_meta')
+        if name == 'scikit-build':
+            yield importlib.import_module('setuptools.build_meta')
+        if name == 'meson-python':
+            setup_env_mpicc()
+            yield importlib.import_module('mesonpy')
     finally:
         if name_saved is None:
             del os.environ['MPI4PY_BUILD_BACKEND']
@@ -39,23 +75,34 @@ def set_build_backend(name='default'):
             os.environ['MPI4PY_BUILD_BACKEND'] = name_saved
 
 
+# ---
+
+
 def get_requires_for_build_sdist(config_settings=None):
-    with set_build_backend() as backend:
+    with build_backend() as backend:
         requires = backend.get_requires_for_build_sdist(config_settings)
+    requires += get_requires_for_build('sdist')
     return requires
+
+
+def build_sdist(
+    sdist_directory,
+    config_settings=None,
+):
+    with build_backend() as backend:
+        return backend.build_sdist(
+            sdist_directory,
+            config_settings,
+        )
+
+
+# ---
 
 
 def get_requires_for_build_wheel(config_settings=None):
-    with set_build_backend() as backend:
+    with build_backend() as backend:
         requires = backend.get_requires_for_build_wheel(config_settings)
-    requires += get_build_requires()
-    return requires
-
-
-def get_requires_for_build_editable(config_settings=None):
-    with set_build_backend() as backend:
-        requires = backend.get_requires_for_build_editable(config_settings)
-    requires += get_build_requires()
+    requires += get_requires_for_build('wheel')
     return requires
 
 
@@ -63,31 +110,10 @@ def prepare_metadata_for_build_wheel(
     metadata_directory,
     config_settings=None,
 ):
-    with set_build_backend() as backend:
+    name = get_backend_name()
+    with build_backend(name) as backend:
         return backend.prepare_metadata_for_build_wheel(
             metadata_directory,
-            config_settings,
-        )
-
-
-def prepare_metadata_for_build_editable(
-    metadata_directory,
-    config_settings=None,
-):
-    with set_build_backend() as backend:
-        return backend.prepare_metadata_for_build_editable(
-            metadata_directory,
-            config_settings,
-        )
-
-
-def build_sdist(
-    sdist_directory,
-    config_settings=None,
-):
-    with set_build_backend() as backend:
-        return backend.build_sdist(
-            sdist_directory,
             config_settings,
         )
 
@@ -98,11 +124,33 @@ def build_wheel(
     metadata_directory=None,
 ):
     name = get_backend_name()
-    with set_build_backend(name) as backend:
+    with build_backend(name) as backend:
         return backend.build_wheel(
             wheel_directory,
             config_settings,
             metadata_directory,
+        )
+
+
+# ---
+
+
+def get_requires_for_build_editable(config_settings=None):
+    with build_backend() as backend:
+        requires = backend.get_requires_for_build_editable(config_settings)
+    requires += get_requires_for_build('editable')
+    return requires
+
+
+def prepare_metadata_for_build_editable(
+    metadata_directory,
+    config_settings=None,
+):
+    name = 'setuptools'  # TODO: support scikit-build
+    with build_backend(name) as backend:
+        return backend.prepare_metadata_for_build_editable(
+            metadata_directory,
+            config_settings,
         )
 
 
@@ -111,20 +159,33 @@ def build_editable(
     config_settings=None,
     metadata_directory=None,
 ):
-    name = 'default'  # TODO: support scikit-build
-    with set_build_backend(name) as backend:
+    name = 'setuptools'  # TODO: support scikit-build
+    with build_backend(name) as backend:
         return backend.build_editable(
             wheel_directory,
             config_settings,
             metadata_directory,
         )
 
+# ---
 
-if not hasattr(_st_bm, 'get_requires_for_build_editable'):
+if get_backend_name() == 'setuptools':
+    try:
+        import setuptools.build_meta as st_bm
+    except ImportError:
+        st_bm = None
+    if not hasattr(st_bm, 'get_requires_for_build_editable'):
+        del get_requires_for_build_editable
+    if not hasattr(st_bm, 'prepare_metadata_for_build_editable'):
+        del prepare_metadata_for_build_editable
+    if not hasattr(st_bm, 'build_editable'):
+        del build_editable
+    del st_bm
+
+if get_backend_name() == 'meson-python':
+    del prepare_metadata_for_build_wheel
     del get_requires_for_build_editable
-
-if not hasattr(_st_bm, 'prepare_metadata_for_build_editable'):
     del prepare_metadata_for_build_editable
-
-if not hasattr(_st_bm, 'build_editable'):
     del build_editable
+
+# ---

--- a/conf/mpiapigen.py
+++ b/conf/mpiapigen.py
@@ -368,7 +368,7 @@ class Generator:
                 nodelist.append(node)
                 break
         if not args:
-            warnings.warn('unmatched line:\n%s' % line)
+            warnings.warn('unmatched line:\n%s' % line, stacklevel=1)
 
     def __iter__(self):
         return iter(self.nodes)

--- a/conf/pyproject-meson.toml
+++ b/conf/pyproject-meson.toml
@@ -1,3 +1,0 @@
-[build-system]
-build-backend = "mesonpy"
-requires = ["meson-python", "cython"]

--- a/conf/requirements-build-mesonpy.txt
+++ b/conf/requirements-build-mesonpy.txt
@@ -1,0 +1,2 @@
+meson-python
+ninja

--- a/setup.py
+++ b/setup.py
@@ -301,22 +301,15 @@ def run_skbuild():
 # --------------------------------------------------------------------
 
 
-def get_backend_name(default='default'):
-    return os.environ.get(
-        'MPI4PY_BUILD_BACKEND', default
-    ).lower().replace('_', '-')
-
-
 def main():
-    backend = get_backend_name()
-    if backend == 'default':
+    import builder
+    name = builder.get_backend_name()
+    if name == 'setuptools':
         run_setup()
-    elif backend in ('setuptools', 'distutils'):
-        run_setup()
-    elif backend in ('scikit-build', 'skbuild'):
+    elif name == 'scikit-build':
         run_skbuild()
     else:
-        sys.exit("Unknown build backend '{}'".format(backend))
+        sys.exit("Unknown build backend " + repr(name))
 
 
 if __name__ == '__main__':

--- a/test/arrayimpl.py
+++ b/test/arrayimpl.py
@@ -27,7 +27,7 @@ try:
         try:
             warnings.warn(
                 'To test Numba GPU arrays, use Numba v0.48.0+.',
-                RuntimeWarning,
+                RuntimeWarning, stacklevel=1,
             )
         except RuntimeWarning:
             pass

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,38 @@ commands =
     {[mpi]mpiexec} -n 5 {envpython} -m mpi4py.futures {toxinidir}/demo/futures/test_futures.py -q []
     {envpython} {toxinidir}/demo/test-run/test_run.py -q []
 
+[testenv:build-cmake]
+labels = build,cmake
+deps = build
+skip_install = true
+allowlist_externals = {[mpi]mpiexec},rm
+passenv = {[env]passenv}
+setenv =
+    CFLAGS=-O0 -Wp,-U_FORTIFY_SOURCE
+    MPI4PY_BUILD_BACKEND=cmake
+commands_pre =
+    rm -rf _skbuild
+commands =
+    {envpython} -m build --outdir {envtmpdir}/dist
+    {envpython} -m pip install --verbose .
+    mpiexec -n 1 {envpython} test/main.py test_package
+
+[testenv:build-meson]
+labels = build,meson
+deps = build
+skip_install = true
+allowlist_externals = {[mpi]mpiexec},rm
+passenv = {[env]passenv}
+setenv =
+    CFLAGS=-O0 -Wp,-U_FORTIFY_SOURCE
+    MPI4PY_BUILD_BACKEND=meson
+commands_pre =
+    rm -rf .mesonpy-*
+commands =
+    {envpython} -m build --outdir {envtmpdir}/dist
+    {envpython} -m pip install --verbose .
+    mpiexec -n 1 {envpython} test/main.py test_package
+
 [testenv:code]
 deps = -r{toxinidir}/conf/requirements-build-cython.txt
 skip_install = true


### PR DESCRIPTION
* Simplify handling of alternative backend names
* Add support for `MPI4PY_BUILD_BACKEND=meson-python`
* Add Tox envs to test {pip|build} with {scikit-build|meson-python}