### PR TITLE
type: Do not install stubs for Python 3.7 or older

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ Release 4.0.0 [2023-XX-XX]
 * Backward-incompatible changes:
 
   * Python 2 is no longer supported, Python 3.6+ is required, but
-    typing stubs are supported for Python 3.7+.
+    typing stubs are supported for Python 3.8+.
 
   * The `Intracomm.Create_group()` method is no longer defined in the
     base `Comm` class.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,20 +112,22 @@ file(
   GLOB mpi4py_SOURCES
   RELATIVE ${SRCDIR}
   ${SRCDIR}/mpi4py/*.py
-  ${SRCDIR}/mpi4py/*.pyi
-  ${SRCDIR}/mpi4py/*.pxd
-  ${SRCDIR}/mpi4py/py.typed
   ${SRCDIR}/mpi4py/futures/*.py
-  ${SRCDIR}/mpi4py/futures/*.pyi
   ${SRCDIR}/mpi4py/util/*.py
-  ${SRCDIR}/mpi4py/util/*.pyi
 )
 file(
   GLOB mpi4py_HEADERS
   RELATIVE ${SRCDIR}
+  ${SRCDIR}/mpi4py/*.pxd
   ${SRCDIR}/mpi4py/include/mpi4py/*.[hi]
   ${SRCDIR}/mpi4py/include/mpi4py/*.px[di]
 )
+if (Python_VERSION VERSION_GREATER_EQUAL 3.11)
+  list(APPEND mpi4py_HEADERS mpi4py/py.typed)
+  foreach(file ${mpi4py_SOURCES})
+    list(APPEND mpi4py_HEADERS ${file}i)
+  endforeach()
+endif()
 foreach(file ${mpi4py_SOURCES} ${mpi4py_HEADERS})
   get_filename_component(dir ${file} DIRECTORY)
   install(FILES ${SRCDIR}/${file} DESTINATION ${dir})

--- a/meson.build
+++ b/meson.build
@@ -123,7 +123,6 @@ package = {
     '__init__.pxd',
     'libmpi.pxd',
     'MPI.pxd',
-    'py.typed',
   ],
   'mpi4py.futures': [
     '__init__.py',
@@ -147,12 +146,6 @@ foreach pkg, src : package
   sources = []
   foreach fn : src
     sources += srcdir / subdir / fn
-    if fn.endswith('.py')
-      pyi = srcdir / subdir / fn + 'i'
-      if fs.exists(pyi)
-        sources += pyi
-      endif
-    endif
   endforeach
   py.install_sources(
     sources,
@@ -165,5 +158,25 @@ install_subdir(
   srcdir / 'mpi4py' / 'include',
   install_dir: dstdir / 'mpi4py',
 )
+
+if py.language_version().version_compare('>=3.8')
+  foreach pkg, src : package
+    subdir = join_paths(pkg.split('.'))
+    sources = []
+    if not pkg.contains('.')
+      sources += srcdir / subdir / 'py.typed'
+    endif
+    foreach fn : src
+      if fn.endswith('.py')
+        sources += srcdir / subdir / fn + 'i'
+      endif
+    endforeach
+    py.install_sources(
+      sources,
+      pure: false,
+      subdir: subdir,
+    )
+  endforeach
+endif
 
 # ---

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,7 @@ package_info = dict(
     },
     package_dir = {'' : 'src'},
 )
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     del package_info['package_data']['mpi4py'][-3:]
 
 

--- a/src/mpi4py/futures/_base.pyi
+++ b/src/mpi4py/futures/_base.pyi
@@ -1,23 +1,13 @@
-import sys
 from concurrent.futures import (
     FIRST_COMPLETED as FIRST_COMPLETED,
     FIRST_EXCEPTION as FIRST_EXCEPTION,
     ALL_COMPLETED as ALL_COMPLETED,
     CancelledError as CancelledError,
     TimeoutError as TimeoutError,
+    BrokenExecutor as BrokenExecutor,
+    InvalidStateError as InvalidStateError,
     Future as Future,
     Executor as Executor,
     wait as wait,
     as_completed as as_completed,
 )
-
-if sys.version_info >= (3, 7):
-    from concurrent.futures import BrokenExecutor as BrokenExecutor
-else:
-    class BrokenExecutor(RuntimeError): ...
-
-if sys.version_info >= (3, 8):
-    from concurrent.futures import InvalidStateError as InvalidStateError
-else:
-    from concurrent.futures._base import Error
-    class InvalidStateError(Error): ...

--- a/src/mpi4py/futures/_core.py
+++ b/src/mpi4py/futures/_core.py
@@ -95,7 +95,7 @@ def _format_exc(exc, comm):
     return f'\n{info}"""\n{body}"""'
 
 
-if sys.version_info > (3, 11):
+if sys.version_info >= (3, 11):
 
     def sys_exception():
         return sys.exception()

--- a/src/mpi4py/futures/aplus.py
+++ b/src/mpi4py/futures/aplus.py
@@ -103,7 +103,7 @@ def _chain_future(new_future, future):
     future.add_done_callback(done_cb)
 
 
-if sys.version_info > (3, 11):
+if sys.version_info >= (3, 11):
 
     def _sys_exception():
         return sys.exception()

--- a/src/mpi4py/typing.pyi
+++ b/src/mpi4py/typing.pyi
@@ -4,15 +4,12 @@ from typing import (
     Any,
     Union,
     Optional,
+    Protocol,
     Sequence,
     List,
     Dict,
     Tuple,
 )
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 from numbers import (
     Integral,
 )

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -34,15 +34,18 @@ class TestImport(unittest.TestCase):
 
 class TestDataFiles(unittest.TestCase):
 
-    @unittest.skipIf(sys.version_info < (3, 7), 'py36')
     def testTyping(self):
+        if sys.version_info < (3, 8):
+            check = self.assertFalse
+        else:
+            check = self.assertTrue
         py_typed = os.path.join(pkgdir, 'py.typed')
-        self.assertTrue(os.path.exists(py_typed))
+        check(os.path.exists(py_typed))
         for root, dirs, files in os.walk(pkgdir):
             for fname in files:
                 if fname.endswith(".py"):
                     pyi = os.path.join(root, f"{fname}i")
-                    self.assertTrue(os.path.exists(pyi))
+                    check(os.path.exists(pyi))
 
     def testCython(self):
         for fname in [


### PR DESCRIPTION
Python 3.7 is too old (and EOLed) and proper testing of typing stubs in CI would require workarounds to silence errors.