### PR TITLE
mpi4py.run: Add convenience command line options

### DIFF
--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -48,12 +48,6 @@ jobs:
     vmImage: 'macOS-11'
   strategy:
     matrix:
-      Python36_MPICH:
-        PYTHON_VERSION: '3.6'
-        MPI: 'mpich'
-      Python36_OpenMPI:
-        PYTHON_VERSION: '3.6'
-        MPI: 'openmpi'
       Python37_MPICH:
         PYTHON_VERSION: '3.7'
         MPI: 'mpich'

--- a/conf/ci/appveyor-artifacts.py
+++ b/conf/ci/appveyor-artifacts.py
@@ -31,7 +31,7 @@ jobids = [job['jobId'] for job in jobs]
 
 if options.verbose:
     print("Downloading AppVeyor artifacts "
-          "account={} branch={}".format(ACCOUNT, BRANCH))
+          f"account={ACCOUNT} branch={BRANCH}")
 for jobid in jobids:
     artifacts_url = APIURL + '/buildjobs/' + jobid + '/artifacts'
     artifacts = requests.get(artifacts_url, timeout=60).json()

--- a/src/mpi4py/run.py
+++ b/src/mpi4py/run.py
@@ -77,10 +77,31 @@ def main():
     import os
     import sys
 
+    def prefix():
+        prefix = os.path.dirname(__spec__.origin)
+        print(prefix, file=sys.stdout)
+        sys.exit(0)
+
     def version():
         from . import __version__
         package = __spec__.parent
-        print(package, __version__, file=sys.stdout)
+        print(f"{package} {__version__}", file=sys.stdout)
+        sys.exit(0)
+
+    def mpi_std_version():
+        from . import rc
+        rc.initialize = rc.finalize = False
+        from . import MPI
+        version, subversion = MPI.Get_version()
+        print(f"MPI {version}.{subversion}", file=sys.stdout)
+        sys.exit(0)
+
+    def mpi_lib_version():
+        from . import rc
+        rc.initialize = rc.finalize = False
+        from . import MPI
+        library_version = MPI.Get_library_version()
+        print(library_version, file=sys.stdout)
         sys.exit(0)
 
     def usage(errmess=None):
@@ -101,7 +122,10 @@ def main():
 
         options = dedent("""
         options:
+          --prefix             show install path and exit
           --version            show version number and exit
+          --mpi-std-version    show MPI standard version and exit
+          --mpi-lib-version    show MPI library version and exit
           -h|--help            show this help message and exit
           -rc <key=value,...>  set 'mpi4py.rc.key=value'
         """).strip()
@@ -136,8 +160,14 @@ def main():
                 break  # Stop processing options
             if args[0] in ('-h', '-help', '--help'):
                 usage()  # Print help and exit
+            if args[0] in ('-prefix', '--prefix'):
+                prefix()  # Print install path and exit
             if args[0] in ('-version', '--version'):
-                version()  # Print version and exit
+                version()  # Print version number and exit
+            if args[0] in ('-mpi-std-version', '--mpi-std-version'):
+                mpi_std_version()  # Print MPI standard version and exit
+            if args[0] in ('-mpi-lib-version', '--mpi-lib-version'):
+                mpi_lib_version()  # Print MPI library version and exit
             try:
                 arg0 = args[0]
                 if arg0.startswith('--'):

--- a/test/coverage.sh
+++ b/test/coverage.sh
@@ -42,24 +42,27 @@ $MPIEXEC -n 2 $PYTHON -m coverage run -m mpi4py.bench              > /dev/null 2
 $MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py.bench qwerty       > /dev/null 2>&1 || true
 $MPIEXEC -n 2 $PYTHON -m coverage run -m mpi4py.bench qwerty       > /dev/null 2>&1 || true
 
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py.run --help > /dev/null
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --version  > /dev/null
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --help     > /dev/null
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -          < /dev/null
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -rc threads=0 -c "import mpi4py.MPI"
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py.run --help        > /dev/null
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --prefix          > /dev/null
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --version         > /dev/null
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --mpi-std-version > /dev/null
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --mpi-lib-version > /dev/null
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --help            > /dev/null
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -                 < /dev/null
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -rc threads=0            -c "import mpi4py.MPI"
 $MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc=thread_level=single -c "import mpi4py.MPI"
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py                                    > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -m                                 > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -c                                 > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -p                                 > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -bad                               > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --bad=a                            > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -rc                                > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -rc=                               > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc                               > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc=a                             > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc=a=                            > /dev/null 2>&1 || true
-$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc==a                            > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py                   > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -m                > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -c                > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -p                > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -bad              > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --bad=a           > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -rc               > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py -rc=              > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc              > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc=a            > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc=a=           > /dev/null 2>&1 || true
+$MPIEXEC -n 1 $PYTHON -m coverage run -m mpi4py --rc==a           > /dev/null 2>&1 || true
 
 $MPIEXEC -n 1 $PYTHON -m coverage run test/test_package.py
 $MPIEXEC -n 1 $PYTHON -m coverage run test/test_toplevel.py


### PR DESCRIPTION
* `python -m mpi4py --prefix` will tell users where the thing is installed. This way users can quickly figure out if they are importing mpi4py from the wrong location.
* `python -m mpi4py --mpi-std-version` to have an idea of the minimum MPI feature set available.
* `python -m mpi4py --mpi-lib-version` to get info on the backend implementation via `MPI_Get_library_version()`.