### PR TITLE
refactor: mpi4py.get_config() now returns an empty dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@
 /src/mpi4py/MPI.h
 /src/mpi4py/MPI_api.h
 /src/mpi4py/MPI.*.so
-/src/mpi4py/mpi.cfg
 /src/mpi4py.egg-info/**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,8 @@ Release 4.0.0 [2023-XX-XX]
 
   * The `mpi4py.dl` module is no longer available.
 
+  * The `mpi4py.get_config` function returns an empty dictionary.
+
 
 Release 3.1.5 [2023-10-04]
 ==========================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,22 +36,6 @@ if (WIN32)
 endif()
 
 
-# mpi4py/mpi.cfg
-set(mpi.cfg ${BINDIR}/mpi.cfg)
-set(config "[mpi]\n")
-if (MPI_C_COMPILER)
-  set(config "${config}mpicc = ${MPI_C_COMPILER}\n")
-endif()
-if (MPI_CXX_COMPILER)
-  set(config "${config}mpicxx = ${MPI_CXX_COMPILER}\n")
-endif()
-if (MPI_Fortran_COMPILER)
-  set(config "${config}mpifort = ${MPI_Fortran_COMPILER}\n")
-endif()
-file(GENERATE OUTPUT ${mpi.cfg} CONTENT ${config})
-install(FILES ${mpi.cfg} DESTINATION mpi4py)
-
-
 # Cython
 set(cythonize ${TOPDIR}/conf/cythonize.py)
 set(Cython_COMMAND ${Python_EXECUTABLE} ${cythonize})

--- a/conf/mpiconfig.py
+++ b/conf/mpiconfig.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 import shlex
 import shutil
 import logging
@@ -21,9 +21,6 @@ class Config:
         self.compiler_info = OrderedDict((
             ('mpicc'  , None),
             ('mpicxx' , None),
-            ('mpifort', None),
-            ('mpif90' , None),
-            ('mpif77' , None),
             ('mpild'  , None),
         ))
         self.library_info = OrderedDict((
@@ -61,22 +58,13 @@ class Config:
     def info(self, log=None):
         if log is None:
             log = self.log
-        mpicc   = self.compiler_info.get('mpicc')
-        mpicxx  = self.compiler_info.get('mpicxx')
-        mpifort = self.compiler_info.get('mpifort')
-        mpif90  = self.compiler_info.get('mpif90')
-        mpif77  = self.compiler_info.get('mpif77')
-        mpild   = self.compiler_info.get('mpild')
+        mpicc  = self.compiler_info.get('mpicc')
+        mpicxx = self.compiler_info.get('mpicxx')
+        mpild  = self.compiler_info.get('mpild')
         if mpicc:
             log.info("MPI C compiler:    %s", mpicc)
         if mpicxx:
             log.info("MPI C++ compiler:  %s", mpicxx)
-        if mpifort:
-            log.info("MPI F compiler:    %s", mpifort)
-        if mpif90:
-            log.info("MPI F90 compiler:  %s", mpif90)
-        if mpif77:
-            log.info("MPI F77 compiler:  %s", mpif77)
         if mpild:
             log.info("MPI linker:        %s", mpild)
 
@@ -323,9 +311,6 @@ class Config:
         COMPILERS = (
             ('mpicc',   ['mpicc']),
             ('mpicxx',  ['mpicxx',  'mpic++', 'mpiCC']),
-            ('mpifort', ['mpifc', 'mpifort', 'mpif90', 'mpif77']),
-            ('mpif90',  ['mpif90']),
-            ('mpif77',  ['mpif77']),
             ('mpild',   []),
         )
         #
@@ -505,13 +490,10 @@ class Config:
 if __name__ == '__main__':
     import optparse
     parser = optparse.OptionParser()
-    parser.add_option("--mpi",     type="string")
-    parser.add_option("--mpicc",   type="string")
-    parser.add_option("--mpicxx",  type="string")
-    parser.add_option("--mpifort", type="string")
-    parser.add_option("--mpif90",  type="string")
-    parser.add_option("--mpif77",  type="string")
-    parser.add_option("--mpild",   type="string")
+    parser.add_option("--mpi",    type="string")
+    parser.add_option("--mpicc",  type="string")
+    parser.add_option("--mpicxx", type="string")
+    parser.add_option("--mpild",  type="string")
     opts, args = parser.parse_args()
 
     cfg = Config()

--- a/conf/mpidistutils.py
+++ b/conf/mpidistutils.py
@@ -372,21 +372,6 @@ cmd_mpi_opts = [
      "overridden by environment variable 'MPILD' "
      "(defaults to 'mpicc' or 'mpicxx' if any is available)"),
 
-    ('mpif77=',  None,
-     "MPI F77 compiler command, "
-     "overridden by environment variable 'MPIF77' "
-     "(defaults to 'mpif77' if available)"),
-
-    ('mpif90=',  None,
-     "MPI F90 compiler command, "
-     "overridden by environment variable 'MPIF90' "
-     "(defaults to 'mpif90' if available)"),
-
-    ('mpifort=',  None,
-     "MPI Fortran compiler command, "
-     "overridden by environment variable 'MPIFORT' "
-     "(defaults to 'mpifort' if available)"),
-
     ('mpicxx=',  None,
      "MPI C++ compiler command, "
      "overridden by environment variable 'MPICXX' "
@@ -1177,14 +1162,6 @@ class build_ext(cmd_build_ext.build_ext):
         self.config_extension(ext)
         cmd_build_ext.build_ext.build_extension(self, ext)
         #
-        if ext.name == 'mpi4py.MPI':
-            dest_dir = os.path.dirname(filename)
-            self.mkpath(dest_dir)
-            mpi_cfg = os.path.join(dest_dir, 'mpi.cfg')
-            log.info("writing %s", mpi_cfg)
-            if not self.dry_run:
-                self.config.dump(filename=mpi_cfg)
-        #
         if ext.name == 'mpi4py.MPI' and sys.platform == 'win32':
             confdir = os.path.dirname(__file__)
             topdir = os.path.dirname(confdir)
@@ -1200,31 +1177,9 @@ class build_ext(cmd_build_ext.build_ext):
                     dry_run=self.dry_run,
                 )
 
-    def copy_extensions_to_source(self):
-        build_py = self.get_finalized_command('build_py')
-        cmd_build_ext.build_ext.copy_extensions_to_source(self)
-        for ext in self.extensions:
-            if ext.name == 'mpi4py.MPI':
-                fullname = self.get_ext_fullname(ext.name)
-                filename = self.get_ext_filename(fullname)
-                dirname = os.path.dirname(filename)
-                dest_dir = os.path.join(self.build_lib, dirname)
-                regular_file = os.path.join(dest_dir, 'mpi.cfg')
-                package = fullname.rpartition('.')[0]
-                package_dir = build_py.get_package_dir(package)
-                inplace_file = os.path.join(package_dir, 'mpi.cfg')
-                self.copy_file(regular_file, inplace_file, level=self.verbose)
-
     def get_outputs(self):
         outputs = cmd_build_ext.build_ext.get_outputs(self)
         for ext in self.extensions:
-            if ext.name == 'mpi4py.MPI':
-                fullname = self.get_ext_fullname(ext.name)
-                filename = self.get_ext_filename(fullname)
-                dirname = os.path.dirname(filename)
-                dest_dir = os.path.join(self.build_lib, dirname)
-                output_file = os.path.join(dest_dir, 'mpi.cfg')
-                outputs.append(output_file)
             if ext.name == 'mpi4py.MPI' and sys.platform == 'win32':
                 pthfile = 'mpi.pth'
                 output_file = os.path.join(self.build_lib, pthfile)

--- a/docs/source/mpi4py.rst
+++ b/docs/source/mpi4py.rst
@@ -251,9 +251,9 @@ Miscellaneous functions
 
 .. autofunction:: mpi4py.profile
 
-.. autofunction:: mpi4py.get_config
-
 .. autofunction:: mpi4py.get_include
+
+.. autofunction:: mpi4py.get_config
 
 
 .. Local variables:

--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ distclean: clean srcclean
 	$(RM) -r build _configtest*
 	$(RM) .*_cache .eggs .tox
 	$(RM) -r htmlcov .coverage .coverage.*
-	$(RM) src/mpi4py/MPI.*.so src/mpi4py/mpi.cfg
+	$(RM) src/mpi4py/MPI.*.so
 	find . -name __pycache__ | xargs $(RM) -r
 fullclean: distclean
 	find . -name '*~' -exec $(RM) -f {} ';'

--- a/meson.build
+++ b/meson.build
@@ -69,17 +69,6 @@ custom_target(
   install_dir: dstdir,
 )
 
-mpicc = compiler.cmd_array()[0]
-mpicc = find_program(mpicc).full_path()
-mpi_cfg = ['[mpi]', 'mpicc = @0@'.format(mpicc)]
-custom_target(
-  output: 'mpi.cfg',
-  capture: true,
-  command: echo + mpi_cfg,
-  install: true,
-  install_dir: dstdir / 'mpi4py',
-)
-
 cython = [py, files('conf' / 'cythonize.py')]
 cython_flags = ['--3str', '--cleanup', '3']
 MPI_ch = custom_target(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [config]
 # mpicc   = mpicc
 # mpicxx  = mpicxx
-# mpifort = mpifort
-# mpif90  = mpif90
-# mpif77  = mpif77
 
 [build]
 # debug = 0

--- a/src/mpi4py/__init__.py
+++ b/src/mpi4py/__init__.py
@@ -103,13 +103,25 @@ def get_include():
 
 
 def get_config():
-    """Return a dictionary with information about MPI."""
+    """Return a dictionary with information about MPI.
+
+    .. versionchanged:: 4.0.0
+       By default, this function returns an empty dictionary. However,
+       downstream packagers and distributors may alter such behavior.
+       To that end, MPI information must be provided under an ``mpi``
+       section within a UTF-8 encoded INI-style configuration file
+       :file:`mpi.cfg` located at the top-level package directory.
+       The configuration file is read and parsed using the
+       `configparser` module.
+
+    """
     # pylint: disable=import-outside-toplevel
-    from os.path import join, dirname
     from configparser import ConfigParser
-    config = join(dirname(__file__), 'mpi.cfg')
+    from os.path import join, dirname
     parser = ConfigParser()
-    parser.read(config, encoding='utf-8')
+    parser.add_section('mpi')
+    mpicfg = join(dirname(__file__), 'mpi.cfg')
+    parser.read(mpicfg, encoding='utf-8')
     return dict(parser.items('mpi'))
 
 


### PR DESCRIPTION
From next release, `mpi4py.get_config()` will return an empty dictionary. However, third-party packagers and distributors can still add an `mpi.cfg` file as package data to provide users with MPI  build information (compiler wrappers, includes, libraries).