### PR TITLE
test: Disable spawn and dynproc tests by default under Open MPI v5.x

### DIFF
--- a/demo/futures/test_futures.py
+++ b/demo/futures/test_futures.py
@@ -1729,9 +1729,14 @@ if name == 'Open MPI':
     if version == (4,0,2) and sys.platform=='darwin':
         SKIP_POOL_TEST = True
     if version == (4,1,2) and sys.platform=='linux':
-        SKIP_POOL_TEST = (os.environ.get('GITHUB_ACTIONS') == 'true')
-    if version == (5,1,0):
-        SKIP_POOL_TEST = ('PMIX_RANK' not in os.environ)
+        github = (os.environ.get('GITHUB_ACTIONS') == 'true')
+        SKIP_POOL_TEST = github
+    if version >= (5,0,0) and version <= (5,1,0):
+        skip_spawn = (
+            os.environ.get('MPI4PY_TEST_SPAWN')
+            in (None, '0', 'no', 'off', 'false')
+        )
+        SKIP_POOL_TEST = skip_spawn
 if name == 'MPICH':
     if sys.platform == 'darwin':
         if version >= (3, 4) and version < (4, 0):

--- a/test/test_dynproc.py
+++ b/test/test_dynproc.py
@@ -30,9 +30,15 @@ def badport():
         port = ""
     return port == ""
 
+def skip_dynproc():
+    return (
+        os.environ.get('MPI4PY_TEST_DYNPROC')
+        in (None, '0', 'no', 'off', 'false')
+    )
+
 @unittest.skipMPI('mpich(<4.3.0)', badport())
 @unittest.skipMPI('openmpi(<2.0.0)')
-@unittest.skipMPI('openmpi(>=5.0.0,<=5.1.0)')
+@unittest.skipMPI('openmpi(>=5.0.0,<=5.1.0)', skip_dynproc())
 @unittest.skipMPI('msmpi(<8.1.0)')
 @unittest.skipMPI('mvapich(<3.0.0)')
 @unittest.skipIf(MPI.COMM_WORLD.Get_size() < 2, 'mpi-world-size<2')

--- a/test/test_spawn.py
+++ b/test/test_spawn.py
@@ -76,6 +76,11 @@ def github():
 def azure():
     return os.environ.get('TF_BUILD') == 'True'
 
+def skip_spawn():
+    return (
+        os.environ.get('MPI4PY_TEST_SPAWN')
+        in (None, '0', 'no', 'off', 'false')
+    )
 
 @unittest.skipMPI('MPI(<2.0)')
 @unittest.skipMPI('openmpi(<3.0.0)')
@@ -83,8 +88,7 @@ def azure():
 @unittest.skipMPI('openmpi(==4.0.1)', macos())
 @unittest.skipMPI('openmpi(==4.0.2)', macos())
 @unittest.skipMPI('openmpi(>=4.1.0,<4.2.0)', github())
-@unittest.skipMPI('openmpi(==5.1.0)', 'PMIX_RANK' not in os.environ)
-@unittest.skipMPI('openmpi(==5.1.0)', MPI.COMM_WORLD.Get_size() > 3)
+@unittest.skipMPI('openmpi(>=5.0.0,<=5.1.0)', skip_spawn())
 @unittest.skipMPI('mpich(<4.1.0)', appnum() is None)
 @unittest.skipMPI('mpich(<4.3.0)', badport())
 @unittest.skipMPI('msmpi(<8.1.0)')
@@ -175,7 +179,6 @@ class BaseTestSpawnSingle(BaseTestSpawn):
         self.COMM.Barrier()
 
 
-@unittest.skipMPI('openmpi(==5.0.0)', macos() and azure())
 class BaseTestSpawnMultiple(BaseTestSpawn):
 
     def testCommSpawn(self):
@@ -309,14 +312,12 @@ class BaseTestSpawnMultiple(BaseTestSpawn):
             self.COMM.Spawn_multiple(CMDS, ARGS, MAXP[0], INFO*2, root=0)
 
 
-@unittest.skipMPI('openmpi(>=5.0.0,<=5.1.0)')
 class TestSpawnSingleSelf(BaseTestSpawnSingle, unittest.TestCase):
     COMM = MPI.COMM_SELF
 
 class TestSpawnSingleWorld(BaseTestSpawnSingle, unittest.TestCase):
     COMM = MPI.COMM_WORLD
 
-@unittest.skipMPI('openmpi(>=5.0.0,<=5.1.0)')
 class TestSpawnSingleSelfMany(TestSpawnSingleSelf):
     MAXPROCS = MPI.COMM_WORLD.Get_size()
 
@@ -324,14 +325,12 @@ class TestSpawnSingleWorldMany(TestSpawnSingleWorld):
     MAXPROCS = MPI.COMM_WORLD.Get_size()
 
 
-@unittest.skipMPI('openmpi(>=5.0.0,<=5.1.0)')
 class TestSpawnMultipleSelf(BaseTestSpawnMultiple, unittest.TestCase):
     COMM = MPI.COMM_SELF
 
 class TestSpawnMultipleWorld(BaseTestSpawnMultiple, unittest.TestCase):
     COMM = MPI.COMM_WORLD
 
-@unittest.skipMPI('openmpi(>=5.0.0,<=5.1.0)')
 class TestSpawnMultipleSelfMany(TestSpawnMultipleSelf):
     MAXPROCS = MPI.COMM_WORLD.Get_size()
 

--- a/test/test_util_pool.py
+++ b/test/test_util_pool.py
@@ -373,6 +373,11 @@ class BaseTestPool:
 def broken_mpi_spawn():
     darwin = (sys.platform == 'darwin')
     windows = (sys.platform == 'win32')
+    github = (os.environ.get('GITHUB_ACTIONS') == 'true')
+    skip_spawn = (
+        os.environ.get('MPI4PY_TEST_SPAWN')
+        in (None, '0', 'no', 'off', 'false')
+    )
     name, version = MPI.get_vendor()
     if name == 'Open MPI':
         if version < (3,0,0):
@@ -384,10 +389,11 @@ def broken_mpi_spawn():
         if version == (4,0,2) and darwin:
             return True
         if version >= (4,1,0) and version < (4,2,0):
-            if os.environ.get('GITHUB_ACTIONS') == 'true':
+            if github:
                 return True
-        if version == (5,1,0):
-            return ('PMIX_RANK' not in os.environ)
+        if version >= (5,0,0) and version <= (5,1,0):
+            if skip_spawn:
+                return True
     if name == 'MPICH':
         if version >= (3, 4) and version < (4, 0) and darwin:
             return True


### PR DESCRIPTION
As a side effect of disabling spawn tests, this also disables testing for the mpi4py.futures and mpi4py.util.pool modules.

* Setenv `MPI4PY_TEST_SPAWN=1` to enable spawn tests.
* Setenv `MPI4PY_TEST_DYNPROC=1` to enable dynproc tests.