### PR TITLE
Use BigMPI if MPI 4.0 is not available

### DIFF
--- a/src/lib-mpi/bigmpi.h
+++ b/src/lib-mpi/bigmpi.h
@@ -1,5 +1,32 @@
+/*
+This code is adapted from Jeff Hammond's BigMPI.
+https://github.com/jeffhammond/BigMPI
 
-//#include <mpi.h>
+The MIT License (MIT)
+
+Copyright (c) 2013, 2014 Argonne National Laboratory
+Copyright (c) 2014       Friedrich-Alexander-Universitaet Erlangen-Nuernberg
+Copyright (c) 2014       Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
 #include <stdint.h>
 #include <limits.h>
 

--- a/src/lib-mpi/bigmpi.h
+++ b/src/lib-mpi/bigmpi.h
@@ -1,0 +1,493 @@
+
+//#include <mpi.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define BIGMPI_COUNT_MAX (SIZE_MAX)
+#define BIGMPI_INT_MAX (INT_MAX)
+#if ( defined(__GNUC__) && (__GNUC__ >= 3) ) || defined(__IBMC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+#  define bmpi_unlikely(x_) __builtin_expect(!!(x_),0)
+#  define bmpi_likely(x_)   __builtin_expect(!!(x_),1)
+#else
+#  define bmpi_unlikely(x_) (x_)
+#  define bmpi_likely(x_)   (x_)
+#endif
+
+static int BigMPI_Type_contiguous(MPI_Aint offset, MPI_Count count, MPI_Datatype oldtype, MPI_Datatype * newtype)
+{
+    /* The count has to fit into MPI_Aint for BigMPI to work. */
+    if ((uint64_t)count>(uint64_t)BIGMPI_COUNT_MAX) {
+        return MPI_ERR_COUNT;
+    }
+
+    MPI_Count c = count/BIGMPI_INT_MAX;
+    MPI_Count r = count%BIGMPI_INT_MAX;
+
+
+    if(c>=BIGMPI_INT_MAX || r>=BIGMPI_INT_MAX){
+        return MPI_ERR_COUNT;
+    }
+
+    MPI_Datatype chunks;
+    MPI_Type_vector(c, BIGMPI_INT_MAX, BIGMPI_INT_MAX, oldtype, &chunks);
+
+    MPI_Datatype remainder;
+    MPI_Type_contiguous(r, oldtype, &remainder);
+
+    MPI_Aint lb /* unused */, extent;
+    MPI_Type_get_extent(oldtype, &lb, &extent);
+
+    MPI_Aint remdisp          = (MPI_Aint)c*BIGMPI_INT_MAX*extent;
+    int blocklengths[2]       = {1,1};
+    MPI_Aint displacements[2] = {offset,offset+remdisp};
+    MPI_Datatype types[2]     = {chunks,remainder};
+    MPI_Type_create_struct(2, blocklengths, displacements, types, newtype);
+
+    MPI_Type_free(&chunks);
+    MPI_Type_free(&remainder);
+
+    return MPI_SUCCESS;
+}
+
+static int MPIX_Type_contiguous_x(MPI_Count count, MPI_Datatype oldtype, MPI_Datatype * newtype)
+{
+    return BigMPI_Type_contiguous(0, count, oldtype, newtype);
+}
+
+
+static int MPIX_Send_x(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Send(buf, (int)count, datatype, dest, tag, comm);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Send(buf, 1, newtype, dest, tag, comm);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Recv_x(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Recv(buf, (int)count, datatype, source, tag, comm, status);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Recv(buf, 1, newtype, source, tag, comm, status);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Isend_x(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request * request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Isend(buf, (int)count, datatype, dest, tag, comm, request);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Isend(buf, 1, newtype, dest, tag, comm, request);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Irecv_x(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request * request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Irecv(buf, (int)count, datatype, source, tag, comm, request);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Irecv(buf, 1, newtype, source, tag, comm, request);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Sendrecv_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, int dest, int sendtag,
+                    void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int source, int recvtag,
+                    MPI_Comm comm, MPI_Status *status)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Sendrecv(sendbuf, (int)sendcount, sendtype, dest, sendtag,
+                          recvbuf, (int)recvcount, recvtype, source, recvtag,
+                          comm, status);
+    } else if (sendcount <= BIGMPI_INT_MAX && recvcount > BIGMPI_INT_MAX ) {
+        MPI_Datatype newrecvtype;
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Sendrecv(sendbuf, (int)sendcount, sendtype, dest, sendtag,
+                          recvbuf, 1, newrecvtype, source, recvtag,
+                          comm, status);
+        MPI_Type_free(&newrecvtype);
+    } else if (sendcount > BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX ) {
+        MPI_Datatype newsendtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        MPI_Type_commit(&newsendtype);
+        rc = MPI_Sendrecv(sendbuf, 1, newsendtype, dest, sendtag,
+                          recvbuf, (int)recvcount, recvtype, source, recvtag,
+                          comm, status);
+        MPI_Type_free(&newsendtype);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Sendrecv(sendbuf, 1, newsendtype, dest, sendtag,
+                          recvbuf, 1, newrecvtype, source, recvtag,
+                          comm, status);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Sendrecv_replace_x(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int sendtag,
+                            int source, int recvtag, MPI_Comm comm, MPI_Status *status)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Sendrecv_replace(buf, (int)count, datatype, dest, sendtag, source, recvtag, comm, status);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Sendrecv_replace(buf, 1, newtype, dest, sendtag, source, recvtag, comm, status);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Isendrecv_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, int dest, int sendtag,
+                    void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int source, int recvtag,
+                    MPI_Comm comm, MPI_Request *request) {
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Isendrecv(sendbuf, (int)sendcount, sendtype, dest, sendtag,
+                          recvbuf, (int)recvcount, recvtype, source, recvtag,
+                          comm, request);
+    } else if (sendcount <= BIGMPI_INT_MAX && recvcount > BIGMPI_INT_MAX ) {
+        MPI_Datatype newrecvtype;
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Isendrecv(sendbuf, (int)sendcount, sendtype, dest, sendtag,
+                          recvbuf, 1, newrecvtype, source, recvtag,
+                          comm, request);
+        MPI_Type_free(&newrecvtype);
+    } else if (sendcount > BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX ) {
+        MPI_Datatype newsendtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        MPI_Type_commit(&newsendtype);
+        rc = MPI_Isendrecv(sendbuf, 1, newsendtype, dest, sendtag,
+                          recvbuf, (int)recvcount, recvtype, source, recvtag,
+                          comm, request);
+        MPI_Type_free(&newsendtype);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Isendrecv(sendbuf, 1, newsendtype, dest, sendtag,
+                          recvbuf, 1, newrecvtype, source, recvtag,
+                          comm, request);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Isendrecv_replace_x(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int sendtag,
+                            int source, int recvtag, MPI_Comm comm, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Isendrecv_replace(buf, (int)count, datatype, dest, sendtag, source, recvtag, comm, request);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Isendrecv_replace(buf, 1, newtype, dest, sendtag, source, recvtag, comm, request);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+
+static int MPIX_Ssend_x(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Ssend(buf, (int)count, datatype, dest, tag, comm);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Ssend(buf, 1, newtype, dest, tag, comm);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Rsend_x(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Rsend(buf, (int)count, datatype, dest, tag, comm);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Rsend(buf, 1, newtype, dest, tag, comm);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Issend_x(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Issend(buf, (int)count, datatype, dest, tag, comm, request);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Issend(buf, 1, newtype, dest, tag, comm, request);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Irsend_x(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Irsend(buf, (int)count, datatype, dest, tag, comm, request);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Irsend(buf, 1, newtype, dest, tag, comm, request);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+
+static int MPIX_Bcast_x(void *buf, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Bcast(buf, (int)count, datatype, root, comm);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Bcast(buf, 1, newtype, root, comm);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Gather_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype,
+                  void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Gather(sendbuf, (int)sendcount, sendtype, recvbuf, (int)recvcount, recvtype, root, comm);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Gather(sendbuf, 1, newsendtype, recvbuf, 1, newrecvtype, root, comm);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Scatter_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype,
+                   void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Scatter(sendbuf, (int)sendcount, sendtype, recvbuf, (int)recvcount, recvtype, root, comm);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Scatter(sendbuf, 1, newsendtype, recvbuf, 1, newrecvtype, root, comm);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Allgather_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype,
+                     void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Allgather(sendbuf, (int)sendcount, sendtype, recvbuf, (int)recvcount, recvtype, comm);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Allgather(sendbuf, 1, newsendtype, recvbuf, 1, newrecvtype, comm);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Alltoall_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype,
+                    void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Alltoall(sendbuf, (int)sendcount, sendtype, recvbuf, (int)recvcount, recvtype, comm);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Alltoall(sendbuf, 1, newsendtype, recvbuf, 1, newrecvtype, comm);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Ibcast_x(void *buf, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (count <= BIGMPI_INT_MAX )) {
+        rc = MPI_Ibcast(buf, (int)count, datatype, root, comm, request);
+    } else {
+        MPI_Datatype newtype;
+        BigMPI_Type_contiguous(0,count, datatype, &newtype);
+        MPI_Type_commit(&newtype);
+        rc = MPI_Ibcast(buf, 1, newtype, root, comm, request);
+        MPI_Type_free(&newtype);
+    }
+    return rc;
+}
+
+static int MPIX_Igather_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype,
+                  void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Igather(sendbuf, (int)sendcount, sendtype, recvbuf, (int)recvcount, recvtype, root, comm, request);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Igather(sendbuf, 1, newsendtype, recvbuf, 1, newrecvtype, root, comm, request);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Iscatter_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype,
+                   void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Iscatter(sendbuf, (int)sendcount, sendtype, recvbuf, (int)recvcount, recvtype, root, comm, request);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Iscatter(sendbuf, 1, newsendtype, recvbuf, 1, newrecvtype, root, comm, request);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Iallgather_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype,
+                     void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Iallgather(sendbuf, (int)sendcount, sendtype, recvbuf, (int)recvcount, recvtype, comm, request);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Iallgather(sendbuf, 1, newsendtype, recvbuf, 1, newrecvtype, comm, request);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}
+
+static int MPIX_Ialltoall_x(void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype,
+                    void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+
+    if (bmpi_likely (sendcount <= BIGMPI_INT_MAX && recvcount <= BIGMPI_INT_MAX )) {
+        rc = MPI_Ialltoall(sendbuf, (int)sendcount, sendtype, recvbuf, (int)recvcount, recvtype, comm, request);
+    } else {
+        MPI_Datatype newsendtype, newrecvtype;
+        BigMPI_Type_contiguous(0,sendcount, sendtype, &newsendtype);
+        BigMPI_Type_contiguous(0,recvcount, recvtype, &newrecvtype);
+        MPI_Type_commit(&newsendtype);
+        MPI_Type_commit(&newrecvtype);
+        rc = MPI_Ialltoall(sendbuf, 1, newsendtype, recvbuf, 1, newrecvtype, comm, request);
+        MPI_Type_free(&newsendtype);
+        MPI_Type_free(&newrecvtype);
+    }
+    return rc;
+}

--- a/src/lib-mpi/largecnt.h
+++ b/src/lib-mpi/largecnt.h
@@ -3,6 +3,8 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "bigmpi.h"
+
 #ifndef PyMPI_MALLOC
   #define PyMPI_MALLOC malloc
 #endif
@@ -158,92 +160,25 @@ static int PyMPI_Buffer_detach_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Send_c
-static int PyMPI_Send_c(void *a1,
-                        MPI_Count a2,
-                        MPI_Datatype a3,
-                        int a4,
-                        int a5,
-                        MPI_Comm a6)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Send(a1, b2, a3, a4, a5, a6);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Send_c MPIX_Send_x
 #undef  MPI_Send_c
 #define MPI_Send_c PyMPI_Send_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Recv_c
-static int PyMPI_Recv_c(void *a1,
-                        MPI_Count a2,
-                        MPI_Datatype a3,
-                        int a4,
-                        int a5,
-                        MPI_Comm a6,
-                        MPI_Status *a7)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Recv(a1, b2, a3, a4, a5, a6, a7);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Recv_c MPIX_Recv_x
 #undef  MPI_Recv_c
 #define MPI_Recv_c PyMPI_Recv_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Sendrecv_c
-static int PyMPI_Sendrecv_c(void *a1,
-                            MPI_Count a2,
-                            MPI_Datatype a3,
-                            int a4,
-                            int a5,
-                            void *a6,
-                            MPI_Count a7,
-                            MPI_Datatype a8,
-                            int a9,
-                            int a10,
-                            MPI_Comm a11,
-                            MPI_Status *a12)
-{
-  int ierr;
-  int b2; int b7;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b7, MPI_Count, a7);
-  ierr = MPI_Sendrecv(a1, b2, a3, a4, a5, a6, b7, a8, a9, a10, a11, a12);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Sendrecv_c MPIX_Sendrecv_x
 #undef  MPI_Sendrecv_c
 #define MPI_Sendrecv_c PyMPI_Sendrecv_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Sendrecv_replace_c
-static int PyMPI_Sendrecv_replace_c(void *a1,
-                                    MPI_Count a2,
-                                    MPI_Datatype a3,
-                                    int a4,
-                                    int a5,
-                                    int a6,
-                                    int a7,
-                                    MPI_Comm a8,
-                                    MPI_Status *a9)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Sendrecv_replace(a1, b2, a3, a4, a5, a6, a7, a8, a9);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Sendrecv_replace_c MPIX_Sendrecv_replace_x
 #undef  MPI_Sendrecv_replace_c
 #define MPI_Sendrecv_replace_c PyMPI_Sendrecv_replace_c
 #endif
@@ -269,133 +204,37 @@ static int PyMPI_Bsend_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Ssend_c
-static int PyMPI_Ssend_c(void *a1,
-                         MPI_Count a2,
-                         MPI_Datatype a3,
-                         int a4,
-                         int a5,
-                         MPI_Comm a6)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Ssend(a1, b2, a3, a4, a5, a6);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Ssend_c MPIX_Ssend_x
 #undef  MPI_Ssend_c
 #define MPI_Ssend_c PyMPI_Ssend_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Rsend_c
-static int PyMPI_Rsend_c(void *a1,
-                         MPI_Count a2,
-                         MPI_Datatype a3,
-                         int a4,
-                         int a5,
-                         MPI_Comm a6)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Rsend(a1, b2, a3, a4, a5, a6);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Rsend_c MPIX_Rsend_x
 #undef  MPI_Rsend_c
 #define MPI_Rsend_c PyMPI_Rsend_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Isend_c
-static int PyMPI_Isend_c(void *a1,
-                         MPI_Count a2,
-                         MPI_Datatype a3,
-                         int a4,
-                         int a5,
-                         MPI_Comm a6,
-                         MPI_Request *a7)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Isend(a1, b2, a3, a4, a5, a6, a7);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Isend_c MPIX_Isend_x
 #undef  MPI_Isend_c
 #define MPI_Isend_c PyMPI_Isend_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Irecv_c
-static int PyMPI_Irecv_c(void *a1,
-                         MPI_Count a2,
-                         MPI_Datatype a3,
-                         int a4,
-                         int a5,
-                         MPI_Comm a6,
-                         MPI_Request *a7)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Irecv(a1, b2, a3, a4, a5, a6, a7);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Irecv_c MPIX_Irecv_x
 #undef  MPI_Irecv_c
 #define MPI_Irecv_c PyMPI_Irecv_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Isendrecv_c
-static int PyMPI_Isendrecv_c(void *a1,
-                             MPI_Count a2,
-                             MPI_Datatype a3,
-                             int a4,
-                             int a5,
-                             void *a6,
-                             MPI_Count a7,
-                             MPI_Datatype a8,
-                             int a9,
-                             int a10,
-                             MPI_Comm a11,
-                             MPI_Request *a12)
-{
-  int ierr;
-  int b2; int b7;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b7, MPI_Count, a7);
-  ierr = MPI_Isendrecv(a1, b2, a3, a4, a5, a6, b7, a8, a9, a10, a11, a12);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Isendrecv_c MPIX_Isendrecv_x
 #undef  MPI_Isendrecv_c
 #define MPI_Isendrecv_c PyMPI_Isendrecv_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Isendrecv_replace_c
-static int PyMPI_Isendrecv_replace_c(void *a1,
-                                     MPI_Count a2,
-                                     MPI_Datatype a3,
-                                     int a4,
-                                     int a5,
-                                     int a6,
-                                     int a7,
-                                     MPI_Comm a8,
-                                     MPI_Request *a9)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Isendrecv_replace(a1, b2, a3, a4, a5, a6, a7, a8, a9);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Isendrecv_replace_c MPIX_Isendrecv_replace_x
 #undef  MPI_Isendrecv_replace_c
 #define MPI_Isendrecv_replace_c PyMPI_Isendrecv_replace_c
 #endif
@@ -422,43 +261,13 @@ static int PyMPI_Ibsend_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Issend_c
-static int PyMPI_Issend_c(void *a1,
-                          MPI_Count a2,
-                          MPI_Datatype a3,
-                          int a4,
-                          int a5,
-                          MPI_Comm a6,
-                          MPI_Request *a7)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Issend(a1, b2, a3, a4, a5, a6, a7);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Issend_c MPIX_Issend_x
 #undef  MPI_Issend_c
 #define MPI_Issend_c PyMPI_Issend_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Irsend_c
-static int PyMPI_Irsend_c(void *a1,
-                          MPI_Count a2,
-                          MPI_Datatype a3,
-                          int a4,
-                          int a5,
-                          MPI_Comm a6,
-                          MPI_Request *a7)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Irsend(a1, b2, a3, a4, a5, a6, a7);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Irsend_c MPIX_Irsend_x
 #undef  MPI_Irsend_c
 #define MPI_Irsend_c PyMPI_Irsend_c
 #endif
@@ -607,43 +416,13 @@ static int PyMPI_Imrecv_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Bcast_c
-static int PyMPI_Bcast_c(void *a1,
-                         MPI_Count a2,
-                         MPI_Datatype a3,
-                         int a4,
-                         MPI_Comm a5)
-{
-  int ierr;
-  int b2;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  ierr = MPI_Bcast(a1, b2, a3, a4, a5);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Bcast_c MPIX_Bcast_x
 #undef  MPI_Bcast_c
 #define MPI_Bcast_c PyMPI_Bcast_c
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Gather_c
-static int PyMPI_Gather_c(void *a1,
-                          MPI_Count a2,
-                          MPI_Datatype a3,
-                          void *a4,
-                          MPI_Count a5,
-                          MPI_Datatype a6,
-                          int a7,
-                          MPI_Comm a8)
-{
-  int ierr;
-  int b2; int b5;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b5, MPI_Count, a5);
-  ierr = MPI_Gather(a1, b2, a3, a4, b5, a6, a7, a8);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Gather_c MPIX_Gather_x
 #undef  MPI_Gather_c
 #define MPI_Gather_c PyMPI_Gather_c
 #endif
@@ -677,24 +456,7 @@ static int PyMPI_Gatherv_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Scatter_c
-static int PyMPI_Scatter_c(void *a1,
-                           MPI_Count a2,
-                           MPI_Datatype a3,
-                           void *a4,
-                           MPI_Count a5,
-                           MPI_Datatype a6,
-                           int a7,
-                           MPI_Comm a8)
-{
-  int ierr;
-  int b2; int b5;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b5, MPI_Count, a5);
-  ierr = MPI_Scatter(a1, b2, a3, a4, b5, a6, a7, a8);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Scatter_c MPIX_Scatter_x
 #undef  MPI_Scatter_c
 #define MPI_Scatter_c PyMPI_Scatter_c
 #endif
@@ -728,23 +490,7 @@ static int PyMPI_Scatterv_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Allgather_c
-static int PyMPI_Allgather_c(void *a1,
-                             MPI_Count a2,
-                             MPI_Datatype a3,
-                             void *a4,
-                             MPI_Count a5,
-                             MPI_Datatype a6,
-                             MPI_Comm a7)
-{
-  int ierr;
-  int b2; int b5;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b5, MPI_Count, a5);
-  ierr = MPI_Allgather(a1, b2, a3, a4, b5, a6, a7);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Allgather_c MPIX_Allgather_x
 #undef  MPI_Allgather_c
 #define MPI_Allgather_c PyMPI_Allgather_c
 #endif
@@ -777,23 +523,7 @@ static int PyMPI_Allgatherv_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Alltoall_c
-static int PyMPI_Alltoall_c(void *a1,
-                            MPI_Count a2,
-                            MPI_Datatype a3,
-                            void *a4,
-                            MPI_Count a5,
-                            MPI_Datatype a6,
-                            MPI_Comm a7)
-{
-  int ierr;
-  int b2; int b5;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b5, MPI_Count, a5);
-  ierr = MPI_Alltoall(a1, b2, a3, a4, b5, a6, a7);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Alltoall_c MPIX_Alltoall_x
 #undef  MPI_Alltoall_c
 #define MPI_Alltoall_c PyMPI_Alltoall_c
 #endif
@@ -1152,25 +882,7 @@ static int PyMPI_Ibcast_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Igather_c
-static int PyMPI_Igather_c(void *a1,
-                           MPI_Count a2,
-                           MPI_Datatype a3,
-                           void *a4,
-                           MPI_Count a5,
-                           MPI_Datatype a6,
-                           int a7,
-                           MPI_Comm a8,
-                           MPI_Request *a9)
-{
-  int ierr;
-  int b2; int b5;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b5, MPI_Count, a5);
-  ierr = MPI_Igather(a1, b2, a3, a4, b5, a6, a7, a8, a9);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Igather_c MPIX_Igather_x
 #undef  MPI_Igather_c
 #define MPI_Igather_c PyMPI_Igather_c
 #endif
@@ -1205,25 +917,7 @@ static int PyMPI_Igatherv_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Iscatter_c
-static int PyMPI_Iscatter_c(void *a1,
-                            MPI_Count a2,
-                            MPI_Datatype a3,
-                            void *a4,
-                            MPI_Count a5,
-                            MPI_Datatype a6,
-                            int a7,
-                            MPI_Comm a8,
-                            MPI_Request *a9)
-{
-  int ierr;
-  int b2; int b5;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b5, MPI_Count, a5);
-  ierr = MPI_Iscatter(a1, b2, a3, a4, b5, a6, a7, a8, a9);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Iscatter_c MPIX_Iscatter_x
 #undef  MPI_Iscatter_c
 #define MPI_Iscatter_c PyMPI_Iscatter_c
 #endif
@@ -1258,24 +952,7 @@ static int PyMPI_Iscatterv_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Iallgather_c
-static int PyMPI_Iallgather_c(void *a1,
-                              MPI_Count a2,
-                              MPI_Datatype a3,
-                              void *a4,
-                              MPI_Count a5,
-                              MPI_Datatype a6,
-                              MPI_Comm a7,
-                              MPI_Request *a8)
-{
-  int ierr;
-  int b2; int b5;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b5, MPI_Count, a5);
-  ierr = MPI_Iallgather(a1, b2, a3, a4, b5, a6, a7, a8);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Iallgather_c MPIX_Iallgather_x
 #undef  MPI_Iallgather_c
 #define MPI_Iallgather_c PyMPI_Iallgather_c
 #endif
@@ -1309,24 +986,7 @@ static int PyMPI_Iallgatherv_c(void *a1,
 #endif
 
 #ifndef PyMPI_HAVE_MPI_Ialltoall_c
-static int PyMPI_Ialltoall_c(void *a1,
-                             MPI_Count a2,
-                             MPI_Datatype a3,
-                             void *a4,
-                             MPI_Count a5,
-                             MPI_Datatype a6,
-                             MPI_Comm a7,
-                             MPI_Request *a8)
-{
-  int ierr;
-  int b2; int b5;
-  PyMPICastValue(int, b2, MPI_Count, a2);
-  PyMPICastValue(int, b5, MPI_Count, a5);
-  ierr = MPI_Ialltoall(a1, b2, a3, a4, b5, a6, a7, a8);
-  if (ierr != MPI_SUCCESS) goto fn_exit;
- fn_exit:
-  return ierr;
-}
+#define PyMPI_Ialltoall_c MPIX_Ialltoall_x
 #undef  MPI_Ialltoall_c
 #define MPI_Ialltoall_c PyMPI_Ialltoall_c
 #endif


### PR DESCRIPTION
I'm not sure when MPI 4.0 will become widely available, so I thought it might be a good idea to use BigMPI to fill in the gap until that happens. Seems like MPICH is the only implementation with support at the moment...