### PR TITLE
fix: Update `mpi.pth` after changes in Python 3.13

### DIFF
--- a/src/mpi.pth
+++ b/src/mpi.pth
@@ -1,23 +1,5 @@
 # Add Intel MPI to Python 3.8+ DLL search path on Windows
-import os; I_MPI_ROOT = os.getenv('I_MPI_ROOT')
-import os; I_MPI_LIBRARY_KIND = os.getenv('I_MPI_LIBRARY_KIND')
-import os; library_kind = os.getenv('library_kind')
-import os; kind = I_MPI_LIBRARY_KIND or library_kind or 'release'
-import os; d1 = I_MPI_ROOT and os.path.join(I_MPI_ROOT, 'bin', kind)
-import os; d2 = I_MPI_ROOT and os.path.join(I_MPI_ROOT, 'bin')
-import os; d1 = d1 and os.path.isfile(os.path.join(d1, 'impi.dll')) and d1
-import os; d2 = d2 and os.path.isfile(os.path.join(d2, 'impi.dll')) and d2
-import os; dlldir = d1 or d2
-import os; add_dll_directory = getattr(os, 'add_dll_directory', None)
-import os; add_dll_directory and dlldir and add_dll_directory(dlldir)
-import sys; verbose = add_dll_directory and dlldir and sys.flags.verbose >= 1
-import sys; verbose and print("# add DLL directory: ", dlldir, file=sys.stderr)
+import sys, os; I_MPI_ROOT = os.getenv('I_MPI_ROOT'); I_MPI_LIBRARY_KIND = os.getenv('I_MPI_LIBRARY_KIND'); library_kind = os.getenv('library_kind'); kind = I_MPI_LIBRARY_KIND or library_kind or 'release'; d1 = I_MPI_ROOT and os.path.join(I_MPI_ROOT, 'bin', kind); d2 = I_MPI_ROOT and os.path.join(I_MPI_ROOT, 'bin'); d1 = d1 and os.path.isfile(os.path.join(d1, 'impi.dll')) and d1; d2 = d2 and os.path.isfile(os.path.join(d2, 'impi.dll')) and d2; dlldir = d1 or d2; add_dll_directory = getattr(os, 'add_dll_directory', None); add_dll_directory and dlldir and add_dll_directory(dlldir); verbose = add_dll_directory and dlldir and sys.flags.verbose >= 1; verbose and print("# add DLL directory: ", dlldir, file=sys.stderr)
 
 # Add Microsoft MPI to Python 3.8+ DLL search path on Windows
-import os; MSMPI_BIN = os.getenv('MSMPI_BIN')
-import os; dll = MSMPI_BIN and os.path.join(MSMPI_BIN, 'msmpi.dll')
-import os; dlldir = dll and os.path.isfile(dll) and MSMPI_BIN
-import os; add_dll_directory = getattr(os, 'add_dll_directory', None)
-import os; add_dll_directory and dlldir and add_dll_directory(dlldir)
-import sys; verbose = add_dll_directory and dlldir and sys.flags.verbose >= 1
-import sys; verbose and print("# add DLL directory: ", dlldir, file=sys.stderr)
+import sys, os; MSMPI_BIN = os.getenv('MSMPI_BIN'); dll = MSMPI_BIN and os.path.join(MSMPI_BIN, 'msmpi.dll'); dlldir = dll and os.path.isfile(dll) and MSMPI_BIN; add_dll_directory = getattr(os, 'add_dll_directory', None); add_dll_directory and dlldir and add_dll_directory(dlldir); verbose = add_dll_directory and dlldir and sys.flags.verbose >= 1; verbose and print("# add DLL directory: ", dlldir, file=sys.stderr)


### PR DESCRIPTION
After semantic changes to `locals()` in Python  3.13, successive lines of `*.pth` files do not preserve values of local variables defined in various lines (starting with `import`). An easy, albeit unaesthetic, fix is to join all these lines with `;` in a single executable line.

https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-locals-semantics 