### PR TITLE
pyupgrade: Refactor Python 2 code to Python 3 constructs.

### DIFF
--- a/demo/init-fini/test_6.py
+++ b/demo/init-fini/test_6.py
@@ -2,7 +2,7 @@ from os import environ
 from warnings import catch_warnings
 from mpi4py import rc
 
-ATTRS = set(a for a in dir(rc) if not a.startswith('_'))
+ATTRS = {a for a in dir(rc) if not a.startswith('_')}
 VALUE = -123456789
 
 for attr in ATTRS:
@@ -13,6 +13,6 @@ with catch_warnings(record=True) as warnings:
     from mpi4py import MPI
 
 template = "mpi4py.rc.{}: unexpected value {}"
-expected = sorted(set(template.format(attr, repr(VALUE)) for attr in ATTRS))
-messages = sorted(set(str(entry.message) for entry in warnings))
+expected = sorted({template.format(attr, repr(VALUE)) for attr in ATTRS})
+messages = sorted({str(entry.message) for entry in warnings})
 assert messages == expected,  "\n" + "\n".join(messages)

--- a/test/test_cco_ngh_obj.py
+++ b/test/test_cco_ngh_obj.py
@@ -14,7 +14,7 @@ messages = list(_basic)
 messages += [
     list(_basic),
     tuple(_basic),
-    dict((f'k{k}', v) for k, v in enumerate(_basic)),
+    {f'k{k}': v for k, v in enumerate(_basic)},
 ]
 messages = messages + [messages]
 

--- a/test/test_cco_obj.py
+++ b/test/test_cco_obj.py
@@ -18,7 +18,7 @@ messages = list(_basic)
 messages += [
     list(_basic),
     tuple(_basic),
-    dict((f'k{k}', v) for k, v in enumerate(_basic)),
+    {f'k{k}': v for k, v in enumerate(_basic)},
 ]
 
 class BaseTestCCOObj:

--- a/test/test_cco_obj_inter.py
+++ b/test/test_cco_obj_inter.py
@@ -18,7 +18,7 @@ messages = list(_basic)
 messages += [
     list(_basic),
     tuple(_basic),
-    dict((f'k{k}', v) for k, v in enumerate(_basic)),
+    {f'k{k}': v for k, v in enumerate(_basic)},
 ]
 
 @unittest.skipMPI('openmpi(<1.6.0)')

--- a/test/test_p2p_obj.py
+++ b/test/test_p2p_obj.py
@@ -22,7 +22,7 @@ messages += [
     tuple(_basic),
     set(_basic),
     frozenset(_basic),
-    dict((f'k{k}', v) for k, v in enumerate(_basic)),
+    {f'k{k}': v for k, v in enumerate(_basic)},
 ]
 
 class BaseTestP2PObj:

--- a/test/test_p2p_obj_matched.py
+++ b/test/test_p2p_obj_matched.py
@@ -14,7 +14,7 @@ messages = list(_basic)
 messages += [
     list(_basic),
     tuple(_basic),
-    dict((f'k{k}', v) for k, v in enumerate(_basic)),
+    {f'k{k}': v for k, v in enumerate(_basic)},
 ]
 
 @unittest.skipIf(MPI.MESSAGE_NULL == MPI.MESSAGE_NO_PROC, 'mpi-message')

--- a/test/test_util_pkl5.py
+++ b/test/test_util_pkl5.py
@@ -24,7 +24,7 @@ messages += [
     tuple(_basic),
     set(_basic),
     frozenset(_basic),
-    dict((f'k{k}', v) for k, v in enumerate(_basic)),
+    {f'k{k}': v for k, v in enumerate(_basic)},
 ]
 
 try:

--- a/test/test_util_pool.py
+++ b/test/test_util_pool.py
@@ -31,7 +31,7 @@ TIMEOUT1 = 0.1
 TIMEOUT2 = 0.2
 
 
-class TimingWrapper(object):
+class TimingWrapper:
 
     def __init__(self, func):
         self.func = func


### PR DESCRIPTION
Refactor Python 2 code to use Python 3 constructs. Notable is the use of `{}` for dicts and sets.

Used [pyupgrade](https://github.com/asottile/pyupgrade) 3.17.0 with `--py3-plus`.