### PR TITLE
docs: Fix get_documenter monkey-patching for Sphinx 8.1

### DIFF
--- a/.github/workflows/ci-abi.yml
+++ b/.github/workflows/ci-abi.yml
@@ -395,6 +395,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
 
+    - name: Set hostname
+      run:  sudo hostname localhost
+      if:   runner.os == 'macOS'
+
     - name: Test mpi4py cmdline (mpi-library)
       run:  mpiexec -n 1 python -m mpi4py --mpi-library
     - name: Test mpi4py cmdline (mpi-std-version)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -270,10 +270,10 @@ def _setup_autodoc(app):
 
     def get_documenter(*args, **kwargs):
         if hasattr(autosummary, "_get_documenter"):
-            obj, args = args[0], args[1:]
+            obj = args[0]  # signature is (obj, parent, *, registry)
             get_documenter = autosummary._get_documenter
         else:
-            obj, args = args[1], (args[0], *args[2:])
+            obj = args[1]  # signature is (app, obj, parent)
             get_documenter = autosummary.get_documenter
         if isinstance(obj, type) and issubclass(obj, BaseException):
             caller = sys._getframe().f_back.f_code.co_name
@@ -281,7 +281,7 @@ def _setup_autodoc(app):
                 if obj.__module__ == "mpi4py.MPI":
                     if obj.__name__ == "Exception":
                         return ExceptionDocumenterCustom
-        return get_documenter(obj, *args, **kwargs)
+        return get_documenter(*args, **kwargs)
 
     from sphinx.ext.autosummary import generate
 


### PR DESCRIPTION
`obj` needs to be passed as the second argument, not the first one.

Fixes #668.

With this change, I can get the Debian package build successfully with both Sphinx 8.1 and 8.2.