### PR TITLE
fixed erroneous documentation of the TargetSpec

### DIFF
--- a/src/mpi4py/typing.py
+++ b/src/mpi4py/typing.py
@@ -235,7 +235,7 @@ Target specification.
 * Tuple[()]
 * Tuple[`Displ`]
 * Tuple[`Displ`, `Count`]
-* Tuple[`Displ`, `Count`, `Datatype`]
+* Tuple[`Displ`, `Count`, `TypeSpec`]
 """
 
 


### PR DESCRIPTION
It was typed with TypeSpec, but documentation
showed Datatype.