### PR TITLE
documented None for rc.finalize

### DIFF
--- a/docs/source/mpi4py.rst
+++ b/docs/source/mpi4py.rst
@@ -63,8 +63,7 @@ Runtime configuration options
 
    Automatic MPI finalization at exit.
 
-   For the value :obj:`None` it instead defaults to the
-   value of :attr:`mpi4py.rc.initialize`.
+   If set to :obj:`None`, the value of :attr:`mpi4py.rc.initialize` is used.
 
    :type: :obj:`None` or :class:`bool`
    :default: :obj:`None`

--- a/docs/source/mpi4py.rst
+++ b/docs/source/mpi4py.rst
@@ -63,6 +63,9 @@ Runtime configuration options
 
    Automatic MPI finalization at exit.
 
+   For the value :obj:`None` it instead defaults to the
+   value of :attr:`mpi4py.rc.initialize`.
+
    :type: :obj:`None` or :class:`bool`
    :default: :obj:`None`
 


### PR DESCRIPTION
It defaults to the `rc.initialize` value.

skip-checks: true