### PR TITLE
Drop 3.13t builds from cibuildwheel configuration

### DIFF
--- a/cibw/wheel-build.sh
+++ b/cibw/wheel-build.sh
@@ -22,7 +22,7 @@ export MPI4PY_BUILD_PYSABI="$pysabi"
 export MPI4PY_LOCAL_VERSION="$mpiabi"
 export CIBW_CONTAINER_ENGINE=$containerengine
 export CIBW_PROJECT_REQUIRES_PYTHON=">=3.10"
-export CIBW_ENABLE="cpython-freethreading pypy"
+export CIBW_ENABLE="pypy"
 export CIBW_BUILD_FRONTEND="build[uv]"
 export CIBW_ARCHS="$arch"
 export CIBW_BUILD="$py-*"


### PR DESCRIPTION
See the note at https://cibuildwheel.pypa.io/en/stable/changelog/#v341 and https://github.com/pypa/cibuildwheel/pull/2787.

This option will be removed in the next release of cibuildwheel.

I'm going through repositories on GitHub that enable this option and sending in PRs to disable it. Happy to answer questions about this.

If you're curious why 3.13t support is going away so soon, see https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel for further guidance.